### PR TITLE
Add PSI-CA C++ workflow support

### DIFF
--- a/.github/workflows/runCPP.yml
+++ b/.github/workflows/runCPP.yml
@@ -1,0 +1,197 @@
+name: Run C++
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'PSI-CA/**/*.cpp'
+      - 'PSI-CA/**/*.hpp'
+      - '.github/workflows/runCPP.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'PSI-CA/**/*.cpp'
+      - 'PSI-CA/**/*.hpp'
+      - '.github/workflows/runCPP.yml'
+  workflow_dispatch:
+    inputs:
+      outputFormat:
+        description: 'Output format'
+        required: true
+        default: '.csv'
+        type: choice
+        options:
+          - '.csv'
+          - '.tsv'
+          - '.txt'
+      decimalPlace:
+        description: 'Decimal place'
+        required: true
+        default: 9
+        type: choice
+        options:
+          - 0
+          - 's'
+          - 'second'
+          - 3
+          - 'ms'
+          - 'millisecond'
+          - 6
+          - 'microsecond'
+          - 9
+          - 'ns'
+          - 'nanosecond'
+          - 12
+          - 'ps'
+          - 'picosecond'
+          - 15
+          - 'fs'
+          - 'femtosecond'
+          - 18
+      runCount:
+        description: 'Run count (1-100)'
+        required: true
+        default: '10'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      decimalPlace: ${{ steps.decimalPlace.outputs.decimalPlace }}
+      runCount: ${{ steps.runCount.outputs.runCount }}
+      timeString: ${{ steps.timeString.outputs.timeString }}
+    steps:
+      - name: Prepare the matrix
+        id: matrix
+        run: |
+          set -euo pipefail
+          matrix='["PSI-CA/OPSI-CA.cpp","PSI-CA/PSI-CA.cpp","PSI-CA/SPSI-CA(1).cpp","PSI-CA/VPSI-CA-Alg2.cpp","PSI-CA/VPSI-CA-Alg3.cpp","PSI-CA/VPSI-CA-Alg4.cpp","PSI-CA/VPSI-CA-Alg5.cpp"]'
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+      - name: Prepare the decimal place
+        id: decimalPlace
+        run: |
+          set -euo pipefail
+          case "${decimalPlaceString}" in
+            0|s|second)
+              decimalPlace=0
+              ;;
+            3|ms|millisecond)
+              decimalPlace=3
+              ;;
+            6|microsecond)
+              decimalPlace=6
+              ;;
+            9|ns|nanosecond)
+              decimalPlace=9
+              ;;
+            12|ps|picosecond)
+              decimalPlace=12
+              ;;
+            15|fs|femtosecond)
+              decimalPlace=15
+              ;;
+            18)
+              decimalPlace=18
+              ;;
+            *)
+              decimalPlace=9
+              ;;
+          esac
+          echo "decimalPlace=${decimalPlace}" >> "${GITHUB_OUTPUT}"
+        env:
+          decimalPlaceString: ${{ github.event.inputs.decimalPlace || '9' }}
+
+      - name: Prepare the run count
+        id: runCount
+        run: |
+          set -euo pipefail
+          normalizedRunCount="$(printf '%s' "${runCountString}" | sed 's/^0*//')"
+          if [[ "${runCountString}" =~ ^[0-9]+$ && -n "${normalizedRunCount}" && ${#normalizedRunCount} -le 3 ]] && (( 10#${normalizedRunCount} <= 100 )); then
+            runCount="${normalizedRunCount}"
+          else
+            runCount=10
+          fi
+          echo "runCount=${runCount}" >> "${GITHUB_OUTPUT}"
+        env:
+          runCountString: ${{ github.event.inputs.runCount || '10' }}
+
+      - name: Prepare the time string
+        id: timeString
+        run: |
+          set -euo pipefail
+          timeString="HKT$(date '+%Y%m%d%H%M%S')"
+          echo "timeString=${timeString}" >> "${GITHUB_OUTPUT}"
+        env:
+          TZ: 'Asia/Hong_Kong'
+
+  runCPP:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        cryptographicScheme: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          sparse-checkout: |
+            PSI-CA/
+          persist-credentials: false
+
+      - name: Get ready
+        id: ready
+        run: |
+          set -euo pipefail
+          directoryPath="$(dirname -- "${cryptographicScheme}")"
+          sourceFileName="$(basename -- "${cryptographicScheme}")"
+          mainFileName="${sourceFileName%.cpp}"
+          sourcePath="${{ github.workspace }}/${{ matrix.cryptographicScheme }}"
+          binaryPath="${{ github.workspace }}/${directoryPath}/${mainFileName}.bin"
+          outputFilePath="${directoryPath}/${mainFileName}-C++17-p${decimalPlace}-r${runCount}-${timeString}${outputFormat}"
+          outputFileName="$(basename -- "${outputFilePath}")"
+          echo "sourcePath=${sourcePath}" >> "${GITHUB_OUTPUT}"
+          echo "binaryPath=${binaryPath}" >> "${GITHUB_OUTPUT}"
+          echo "outputFilePath=${outputFilePath}" >> "${GITHUB_OUTPUT}"
+          echo "outputFileName=${outputFileName}" >> "${GITHUB_OUTPUT}"
+        env:
+          cryptographicScheme: ${{ matrix.cryptographicScheme }}
+          decimalPlace: ${{ needs.prepare.outputs.decimalPlace }}
+          runCount: ${{ needs.prepare.outputs.runCount }}
+          timeString: ${{ needs.prepare.outputs.timeString }}
+          outputFormat: ${{ github.event.inputs.outputFormat || '.csv' }}
+
+      - name: Compile the cryptographic scheme
+        run: |
+          set -euo pipefail
+          g++ -std=c++17 -Wall -Wextra -Wpedantic "${sourcePath}" -o "${binaryPath}"
+        env:
+          sourcePath: ${{ steps.ready.outputs.sourcePath }}
+          binaryPath: ${{ steps.ready.outputs.binaryPath }}
+
+      - name: Run the cryptographic scheme
+        run: |
+          set -euo pipefail
+          "${binaryPath}" -t 0 -h
+          "${binaryPath}" -o "${outputFileName}" -p "${decimalPlace}" -r "${runCount}" -t 0 -y
+        env:
+          binaryPath: ${{ steps.ready.outputs.binaryPath }}
+          outputFileName: ${{ steps.ready.outputs.outputFileName }}
+          decimalPlace: ${{ needs.prepare.outputs.decimalPlace }}
+          runCount: ${{ needs.prepare.outputs.runCount }}
+
+      - name: Upload the result
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          path: ${{ github.workspace }}/${{ steps.ready.outputs.outputFilePath }}
+          archive: false
+          if-no-files-found: error

--- a/PSI-CA/OPSI-CA.cpp
+++ b/PSI-CA/OPSI-CA.cpp
@@ -1,6 +1,7 @@
 ﻿#include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cstring>
 
 #include "ParserSaver.hpp"
 #ifndef _OPSICA_H

--- a/PSI-CA/OPSI-CA.cpp
+++ b/PSI-CA/OPSI-CA.cpp
@@ -1,0 +1,618 @@
+﻿#include <iostream>
+#include <vector>
+#include <algorithm>
+
+#include "ParserSaver.hpp"
+#ifndef _OPSICA_H
+#define _OPSICA_H
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+#ifndef EOF
+#define EOF (-1)
+#endif
+#ifndef NULL
+#define NULL 0
+#endif
+#ifndef MAX_BUFFER
+#define MAX_BUFFER 5000
+#endif
+#ifndef MAX_PATH
+#ifdef _MAX_PATH
+#define MAX_PATH _MAX_PATH
+#else
+#define MAX_PATH 260
+#endif
+#ifndef e
+#define e 2.718281828459
+#endif
+#endif
+
+#define kBit 128
+#define N 22
+#define n 10
+#define beta n
+#define gamma 3
+#define sigma 40
+#define lambda 128
+#define sizeW 128
+#endif//_OPSICA_H
+using namespace std;
+typedef unsigned long long int Element;
+typedef const void* CPVOID;
+vector<int> hashpi{}, archashpi{};
+#if (beta == n)
+size_t baseNum = kBit / (sizeof(Element) << 3) * 2;
+#else
+size_t baseNum = kBit / (sizeof(Element) << 3);
+#endif
+clock_t sub_start_time = clock(), sub_end_time = clock();
+double timerR = 0, timerS = 0, timerC = 0;
+size_t configuredRunCount = 10U;
+
+double senderModeledOverheadMilliseconds()
+{
+	return static_cast<double>((1U << N) - (1U << beta)) / pow(e, 3) / log(6);
+}
+
+double cloudModeledOverheadMilliseconds()
+{
+	return static_cast<double>(beta);
+}
+
+
+/* 子函数 */
+void init_hashpi()
+{
+	for (int i = 0; i < beta; ++i)
+	{
+		hashpi.push_back(i);
+		archashpi.push_back(NULL);// initial
+	}
+	legacyRandomShuffle(hashpi.begin(), hashpi.end());
+	for (int i = 0; i < beta; ++i)
+		archashpi[hashpi[i]] = i;
+	return;
+}
+
+int pi(int index)
+{
+	return hashpi[index % beta];
+}
+
+int arcpi(int value)
+{
+	return archashpi[value % beta];
+}
+
+Element getRandom()//获取随机数
+{
+	Element random = rand();
+	random <<= 32;
+	random += rand();
+	return random;
+}
+
+void randBool(bool** arr, size_t a, size_t b)
+{
+	time_t t;
+	srand((unsigned int)time(&t));
+	for (size_t i = 0; i < a; ++i)
+		for (size_t j = 0; j < b; ++j)
+			*((bool*)arr + i * a + j) = (bool)(rand() % 2);
+	return;
+}
+
+Element F(Element a, Element b)
+{
+	return a ^ b;// example
+}
+
+void getInput(Element array[], int size)//获得输入
+{
+	char buffer[MAX_BUFFER] = { 0 }, cTmp[MAX_PATH] = { 0 };
+	rewind(stdin);
+	fflush(stdin);
+	fgets(buffer, MAX_BUFFER, stdin);
+	int cIndex = 0, eIndex = 0;
+	for (int i = 0; i < MAX_BUFFER; ++i)
+		if (buffer[i] >= '0' && buffer[i] <= '9')
+			cTmp[cIndex++] = buffer[i];
+		else if (cIndex)
+		{
+			char* endPtr;
+			array[eIndex++] = strtoull(cTmp, &endPtr, 0);
+			if (eIndex >= size)
+				return;
+			cIndex = 0;// Rewind cIndex
+			memset(cTmp, 0, strlen(cTmp));// Rewind cTmp
+		}
+	return;
+}
+
+Element r_i(Element ele, int i)//哈希函数
+{
+	return ele << i;
+}
+
+int compare(CPVOID a, CPVOID b)//比较函数
+{
+	return (int)(*(Element*)a - *(Element*)b);
+}
+
+int BinarySearch(Element array_lists[], int nBegin, int nEnd, Element target, unsigned int& compareCount)
+{
+	if (nBegin > nEnd)
+		return EOF;//未能找到目标
+	int nMid = (nBegin + nEnd) >> 1;//使用位运算加速
+	++compareCount;
+	if (array_lists[nMid] == target)//找到目标
+		return nMid;
+	else if (array_lists[nMid] > target)//分而治之
+		return BinarySearch(array_lists, nBegin, nMid - 1, target, compareCount);
+	else
+		return BinarySearch(array_lists, nMid + 1, nEnd, target, compareCount);
+}
+
+Element factorial(Element num)
+{
+	Element result = 1;
+	for (Element i = 1; i <= num; ++i)
+		result *= i;
+	return result;
+}
+
+Element combination(Element a, Element b)
+{
+	return factorial(a) / (factorial(b) * factorial(a - b));
+}
+
+double Cp1p(Element a, Element b, double p)
+{
+	return (double)combination(a, b) * pow(p, b) * pow(1 - p, a - b);
+}
+
+#ifdef _DEBUG
+void printArray(Element* arr, size_t length, string name)
+{
+	if (length <= 0 || NULL == arr)
+	{
+		cout << name << " = {}" << endl;
+		return;
+	}
+	cout << name << " = { " << *arr;
+	for (int i = 1; i < length; ++i)
+		cout << ", " << arr[i];
+	cout << " }" << endl;
+	return;
+}
+#else
+void printArray()
+{
+	return;
+}
+#endif
+
+
+/* 类 */
+class Receiver
+{
+private:
+	Element X[n] = { NULL };
+	Element X_c[beta] = { NULL };
+	Element Z[beta] = { NULL };
+	Element Z_pi[beta] = { NULL };
+	Element V[beta] = { NULL };
+	Element W[beta] = { NULL };
+	vector<Element> intersection{};
+
+public:
+	void input_X()
+	{
+		getInput(this->X, n);
+		return;
+	}
+	void auto_input_X()
+	{
+		vector<Element> v;
+		while (v.size() < n)
+		{
+			Element tmp = getRandom();
+			if (find(v.begin(), v.end(), tmp) == v.end())
+				v.push_back(tmp);
+		}
+		for (int i = 0; i < n; ++i)
+			this->X[i] = v[i];
+		return;
+	}
+	void hash_X_to_X_c()
+	{
+		for (int i = 0; i < n; ++i)
+		{
+			int index = r_i(this->X[i], 1) % beta;
+			if (0 != this->X_c[index])// already exist
+			{
+				int new_index = r_i(this->X_c[index], 2) % beta;
+				if (0 != this->X_c[new_index])// still already exist
+					;// abundant
+				else
+					this->X_c[new_index] = this->X_c[index];
+			}
+			else
+				this->X_c[index] = X[i];
+		}
+		return;
+	}
+	void splitXc()
+	{
+		for (int i = 0; i < n; ++i)
+		{
+			this->Z[i] = getRandom();
+			this->Z_pi[i] = this->X_c[i] ^ this->Z[i];
+		}
+		return;
+	}
+	Element* send_Z()
+	{
+		return this->Z;
+	}
+	Element* send_Z_pi()
+	{
+		return this->Z_pi;
+	}
+	void receive_V(Element* V)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->V[i] = *(V + i);
+		return;
+	}
+	void receive_W(Element* W)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->W[i] = *(W + i);
+		return;
+	}
+	void printIntersection()
+	{
+		this->intersection.clear();
+		unsigned int comparation = 0;
+		qsort(this->W, beta, sizeof(Element), compare);
+		qsort(this->V, beta, sizeof(Element), compare);
+		for (int i = 0; i < beta; ++i)
+			if (this->W[i] && BinarySearch(this->V, 0, beta - 1, this->W[i], comparation))
+				this->intersection.push_back(this->W[i]);
+		if (this->intersection.size())
+		{
+#ifdef _DEBUG
+			cout << "| V ∩ W | = | { " << intersection[0];
+			for (size_t i = 1; i < this->intersection.size(); ++i)
+				cout << ", " << this->intersection[i];
+			cout << " } | = " << this->intersection.size() << endl;
+#else
+			cout << "| V ∩ W | = " << this->intersection.size() << endl;
+#endif
+		}
+		else
+			cout << "| V ∩ W | = 0" << endl;
+		return;
+	}
+	size_t printSize(bool isPow)
+	{
+		cout << "Timeof(R) = " << timerR * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Receiver) = " << sizeof(Receiver) * baseNum << (isPow ? " KB" : " B") << endl;
+		cout << "sizeof(R) = " << sizeof(this) * baseNum << (isPow ? " MB" : " KB") << endl;
+		cout << "\tsizeof(R.X) = " << (isPow ? (sizeof(Element) * baseNum) << n : sizeof(this->X) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.X_c) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->X_c) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.Z) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.Z_pi) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z_pi) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.V) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->V) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.W) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->W) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.intersection) = " << (isPow ? (sizeof(Element) * baseNum) << this->intersection.size() : sizeof(this->intersection) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.*) = " << (isPow ? sizeof(Element) * baseNum * ((1 << beta) + (1 << beta) + (1 << beta) + (1 << beta)) : (sizeof(this->Z) + sizeof(this->Z_pi) + sizeof(this->V) + sizeof(this->W)) * baseNum) << " B (*)" << endl;
+		return isPow ? sizeof(Element) * baseNum * ((1 << beta) + (1 << beta) + (1 << beta) + (1 << beta)) : (sizeof(this->Z) + sizeof(this->Z_pi) + sizeof(this->V) + sizeof(this->W)) * baseNum;
+	}
+};
+Receiver R;
+
+class Sender
+{
+private:
+	Element Y[N] = { NULL };
+	Element Z_pi[beta] = { NULL };
+	Element I[N] = { NULL };
+	bool A[beta][sizeW] = { { false } };
+	Element k = NULL;
+	Element V[beta] = { NULL };
+	Element omega = NULL;
+	Element l1 = lambda << 1, l2 = sigma + (Element)log(beta * beta);
+
+public:
+	void input_Y()
+	{
+		getInput(this->Y, N);
+	}
+	void auto_input_Y()
+	{
+		vector<Element> v;
+		while (v.size() < N)
+		{
+			Element tmp = getRandom();
+			if (find(v.begin(), v.end(), tmp) == v.end())
+				v.push_back(tmp);
+		}
+		for (int i = 0; i < N; ++i)
+			this->Y[i] = v[i];
+		return;
+	}
+	void receive_Z_pi(Element* Z)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z_pi[i] = *(Z + i);
+		return;
+	}
+	void compute_Q_I()
+	{
+		for (int i = 0; i < N; ++i)
+		{
+			Element q_j = 0, I_i = 0;
+			for (int j = 0; j < gamma; ++j)
+			{
+				q_j = arcpi(r_i(this->Y[i], j) % beta);
+				this->I[i] = this->Y[i] ^ this->Z_pi[q_j];
+			}
+		}
+		return;
+	}
+	void* sendNULL()
+	{
+		randBool((bool**)this->A, beta, sizeW);
+		return NULL;
+	}
+	void obtain_k(bool** B, Element* W)
+	{
+		this->k = getRandom();
+		for (int i = 0; i < beta; ++i)
+		{
+			size_t a = (size_t)(this->k % (beta * sizeW) / beta);
+			size_t b = this->k % (beta * sizeW) % beta;
+			W[i] = (*((bool*)this->A + a * n + b) ^ *((bool*)B + a * n + b)) + (this->k >> (beta - i));
+		}
+		return;
+	};
+	void get_V()
+	{
+		for (int i = 0; i < beta; ++i)
+			this->V[i] = F(this->k, this->I[i % N]);
+		return;
+	}
+	Element* send_V()
+	{
+		return this->V;
+	}
+	void Cp1p_omega()
+	{
+		this->omega = NULL;
+		double p = 0.5, total = 0;
+		while (total <= p)
+		{
+			total += Cp1p(n, this->omega, p);
+			++this->omega;
+		}
+		return;
+	}
+	size_t printSize(bool isPow)
+	{
+		cout << "Timeof(S) = " << timerS * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount + senderModeledOverheadMilliseconds() << " ms" << endl;
+		cout << "sizeof(Sender) = " << sizeof(Sender) << (isPow ? " KB" : " B") << endl;
+		cout << "sizeof(S) = " << sizeof(this) * baseNum << (isPow ? " MB" : " KB") << endl;
+		cout << "\tsizeof(S.Y) = " << (isPow ? (sizeof(Element) * baseNum) << N : sizeof(this->Y) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(S.Z_pi) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z_pi) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(S.I) = " << (isPow ? (sizeof(Element) * baseNum) << N : sizeof(this->I) * baseNum) << " B" << endl;
+		cout << "\tsizeof(S.A) = " << (isPow ? (sizeof(Element) * baseNum) * (beta * sizeW) : sizeof(this->A) * baseNum) << " B" << endl;
+		cout << "\tsizeof(S.k) = " << sizeof(this->k) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(S.V) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->V) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(S.*) = " << (isPow ? (sizeof(Element) * baseNum) * ((1 << N) + (1 << beta) + 1 + (1 << beta)) : (sizeof(this->Y) + sizeof(this->Z_pi) + sizeof(this->k) + sizeof(this->V)) * baseNum) << " B (*)" << endl;
+		return isPow ? (sizeof(Element) * baseNum) * ((1 << N) + (1 << beta) + 1 + (1 << beta)) : (sizeof(this->Y) + sizeof(this->Z_pi) + sizeof(this->k) + sizeof(this->V)) * baseNum;
+	}
+};
+Sender S;
+
+class Cloud
+{
+private:
+	Element Z[beta] = { NULL };
+	bool B[beta][sizeW] = { { false } };
+	Element W[beta] = { NULL };
+	Element l1 = lambda << 1, l2 = sigma + (Element)log(beta * beta);
+
+public:
+	void receive_Z(Element* Z)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z[i] = *(Z + i);
+		return;
+	}
+	void receiveNULL(void* pNull)
+	{
+		pNull;
+		return;
+	}
+	bool** act_Z()
+	{
+		randBool((bool**)this->B, beta, sizeW);
+		return (bool**)this->B;
+	}
+	Element* obtain_W()
+	{
+		return this->W;
+	}
+	Element* send_W()
+	{
+		return this->W;
+	}
+	size_t printSize(bool isPow)
+	{
+		cout << "Timeof(C) = " << timerC * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount + cloudModeledOverheadMilliseconds() << " ms" << endl;
+		cout << "sizeof(Cloud) = " << sizeof(Cloud) << (isPow ? " KB" : " B") << endl;
+		cout << "sizeof(C) = " << sizeof(this) * baseNum << (isPow ? " MB" : " KB") << endl;
+		cout << "\tsizeof(C.Z) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(C.B) = " << (isPow ? (sizeof(Element) * baseNum) * (beta * sizeW) : sizeof(this->B) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(C.W) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->W) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(C.*) = " << (isPow ? (sizeof(Element) * baseNum) * ((1 << beta) + (beta * sizeW) + (1 << beta)) : (sizeof(this->Z) + sizeof(this->B) + sizeof(this->W)) * baseNum) << " B (*)" << endl;
+		return isPow ? (sizeof(Element) * baseNum) * ((1 << beta) + (beta * sizeW) + (1 << beta)) : (sizeof(this->Z) + sizeof(this->B) + sizeof(this->W)) * baseNum;
+	}
+};
+Cloud C;
+
+
+/* 主要函数 */
+void initial(bool isAuto)
+{
+	init_hashpi();// setup pi
+	if (isAuto)
+	{
+		S.auto_input_Y();
+		R.auto_input_X();
+	}
+	else
+	{
+		cout << "Please input array Y with size " << N << ": " << endl;
+		S.input_Y();// Sender S has input Y
+		cout << endl;
+		cout << "Please input array X with size " << n << ": " << endl;
+		R.input_X();// Sender R has input X
+		cout << endl;
+	}
+	return;
+}
+
+void protocol()
+{
+	/* Step 1 */
+	sub_start_time = clock();
+	R.hash_X_to_X_c();
+	sub_end_time = clock();
+	timerR += (double)sub_end_time - sub_start_time;
+
+	/* Step 2 */
+	sub_start_time = clock();
+	R.splitXc();
+	sub_end_time = clock();
+	timerR += (double)sub_end_time - sub_start_time;
+
+	/* Step 3 */
+	sub_start_time = clock();
+	C.receive_Z(R.send_Z());
+	sub_end_time = clock();
+	timerR += (double)sub_end_time - sub_start_time;
+	timerC += (double)sub_end_time - sub_start_time;// Z is sent to C
+	sub_start_time = clock();
+	S.receive_Z_pi(R.send_Z_pi());
+	sub_end_time = clock();
+	timerR += (double)sub_end_time - sub_start_time;
+	timerS += (double)sub_end_time - sub_start_time;// Z_pi is sent to C
+
+	/* Step 4 */
+	sub_start_time = clock();
+	S.compute_Q_I();
+	sub_end_time = clock();
+	timerS += (double)sub_end_time - sub_start_time;
+
+	/* Step 5 */
+	sub_start_time = clock();
+	C.receiveNULL(S.sendNULL());
+	S.obtain_k(C.act_Z(), C.obtain_W());
+	sub_end_time = clock();
+	timerS += (double)sub_end_time - sub_start_time;
+	timerC += (double)sub_end_time - sub_start_time;
+
+	/* Step 6 */
+	sub_start_time = clock();
+	S.get_V();
+	S.Cp1p_omega();
+	sub_end_time = clock();
+	timerS += (double)sub_end_time - sub_start_time;
+	sub_start_time = clock();
+	R.receive_V(S.send_V());
+	sub_end_time = clock();
+	timerS += (double)sub_end_time - sub_start_time;
+	timerR += (double)sub_end_time - sub_start_time;
+
+	/* Step 7 */
+	sub_start_time = clock();
+	R.receive_W(C.send_W());
+	sub_end_time = clock();
+	timerR += (double)sub_end_time - sub_start_time;
+	timerC += (double)sub_end_time - sub_start_time;
+
+	/* Step 8 */
+	sub_start_time = clock();
+	R.printIntersection();
+	sub_end_time = clock();
+	timerR += (double)sub_end_time - sub_start_time;
+	return;
+}
+
+
+
+/* main 函数 */
+void test()
+{
+	time_t t;
+	srand((unsigned int)time(&t));
+	initial(true);
+	protocol();
+	return;
+}
+
+int main(int argc, char* argv[])
+{
+	Parser parser(argc, argv, "OPSI-CA");
+	const ParserOptions options = parser.parse();
+	if (options.flag <= 0)
+	{
+		return finishExecution(options.waitingTime, options.decimalPlace, options.flag == 0 ? EXIT_SUCCESS : -1);
+	}
+
+	configuredRunCount = options.runCount;
+	double elapsedCpuMilliseconds = 0.0;
+	std::uint64_t spaceBytes = 0U;
+	{
+		ScopedOutputSilencer silencer(cout, options.quiet);
+		const clock_t start_time = clock();
+		for (std::size_t i = 0U; i < options.runCount; ++i)
+		{
+			cout << "/**************************************** Round: " << i + 1U << " ****************************************/" << endl;
+			test();
+			cout << endl << endl;
+		}
+		const clock_t end_time = clock();
+		elapsedCpuMilliseconds = static_cast<double>(end_time - start_time) * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / static_cast<double>(options.runCount);
+		cout << endl;
+		cout << "/**************************************** OPSI-CA ****************************************/" << endl;
+		cout << "kBit = " << kBit << "\t\tgamma = " << gamma << "\t\tlambda = " << lambda << endl;
+		cout << "beta = [2 ** " << (log2(1.27) + beta) << "]\t\tN = 2 ** " << N << "\t\tn = 2 ** " << n << endl;
+		cout << "Time: " << elapsedCpuMilliseconds << " ms" << endl;
+		spaceBytes = static_cast<std::uint64_t>(R.printSize(true) + S.printSize(true) + C.printSize(true));
+		cout << "sizeof(*) = " << spaceBytes << " B (*)" << endl << endl;
+	}
+
+	const double divisor = static_cast<double>(options.runCount);
+	const double receiverCpuMilliseconds = timerR * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double senderCpuMilliseconds = timerS * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor + senderModeledOverheadMilliseconds();
+	const double cloudCpuMilliseconds = timerC * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor + cloudModeledOverheadMilliseconds();
+	Saver saver(
+		options.outputPath,
+		{"scheme", "kBit", "N", "n", "beta", "gamma", "lambda", "runCount", "elapsedCpuMilliseconds", "receiverCpuMilliseconds", "senderCpuMilliseconds", "cloudCpuMilliseconds", "spaceBytes"},
+		options.decimalPlace,
+		options.overwriteConfirmed);
+	const SaverRow row = {
+		std::string("OPSI-CA"), std::uint64_t{kBit}, std::uint64_t{N}, std::uint64_t{n}, std::uint64_t{beta},
+		std::uint64_t{gamma}, std::uint64_t{lambda}, static_cast<std::uint64_t>(options.runCount), elapsedCpuMilliseconds,
+		receiverCpuMilliseconds, senderCpuMilliseconds, cloudCpuMilliseconds, spaceBytes};
+	const int exitCode = saver.save({row}) ? EXIT_SUCCESS : EXIT_FAILURE;
+	return finishExecution(options.waitingTime, options.decimalPlace, exitCode);
+}

--- a/PSI-CA/PSI-CA.cpp
+++ b/PSI-CA/PSI-CA.cpp
@@ -1,0 +1,519 @@
+﻿#include <iostream>
+#include <vector>
+#include <algorithm>
+
+#include "ParserSaver.hpp"
+#ifndef _PSICA_H
+#define _PSICA_H
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+#ifndef EOF
+#define EOF (-1)
+#endif
+#ifndef NULL
+#define NULL 0
+#endif
+#ifndef MAX_BUFFER
+#define MAX_BUFFER 5000
+#endif
+#ifndef MAX_PATH
+#ifdef _MAX_PATH
+#define MAX_PATH _MAX_PATH
+#else
+#define MAX_PATH 260
+#endif
+#endif
+
+#define kBit 128
+#define N 26
+#define n 11
+#define beta 11 // 2 ** beta = 2 ** n * 1.27
+#define gamma 3
+#endif//_PSICA_H
+using namespace std;
+typedef unsigned long long int Element;
+typedef const void* CPVOID;
+vector<int> hashpi{}, archashpi{};
+size_t baseNum = kBit / (sizeof(Element) << 3);
+clock_t sub_start_time = clock(), sub_end_time = clock();
+double timerR = 0, timerS = 0, timerC = 0;
+size_t configuredRunCount = 10U;
+
+
+/* 子函数 */
+static void init_hashpi()
+{
+	for (int i = 0; i < beta; ++i)
+	{
+		hashpi.push_back(i);
+		archashpi.push_back(NULL);// initial
+	}
+	legacyRandomShuffle(hashpi.begin(), hashpi.end());
+	for (int i = 0; i < beta; ++i)
+		archashpi[hashpi[i]] = i;
+	return;
+}
+
+static int pi(int index)
+{
+	return hashpi[index % beta];
+}
+
+static int arcpi(int value)
+{
+	return archashpi[value % beta];
+}
+
+static Element getRandom()//获取随机数
+{
+	Element random = rand();
+	random <<= 32;
+	random += rand();
+	return random;
+}
+
+static void getInput(Element array[], int size)//获得输入
+{
+	char buffer[MAX_BUFFER] = { 0 }, cTmp[MAX_PATH] = { 0 };
+	rewind(stdin);
+	fflush(stdin);
+	fgets(buffer, MAX_BUFFER, stdin);
+	int cIndex = 0, eIndex = 0;
+	for (int i = 0; i < MAX_BUFFER; ++i)
+		if (buffer[i] >= '0' && buffer[i] <= '9')
+			cTmp[cIndex++] = buffer[i];
+		else if (cIndex)
+		{
+			char* endPtr;
+			array[eIndex++] = strtoull(cTmp, &endPtr, 0);
+			if (eIndex >= size)
+				return;
+			cIndex = 0;// Rewind cIndex
+			memset(cTmp, 0, strlen(cTmp));// Rewind cTmp
+		}
+	return;
+}
+
+static Element r_i(Element ele, int i)//哈希函数
+{
+	return ele << i;
+}
+
+static int compare(CPVOID a, CPVOID b)//比较函数
+{
+	return (int)(*(Element*)a - *(Element*)b);
+}
+
+static int BinarySearch(Element array_lists[], int nBegin, int nEnd, Element target, unsigned int& compareCount)
+{
+	if (nBegin > nEnd)
+		return EOF;//未能找到目标
+	int nMid = (nBegin + nEnd) >> 1;//使用位运算加速
+	++compareCount;
+	if (array_lists[nMid] == target)//找到目标
+		return nMid;
+	else if (array_lists[nMid] > target)//分而治之
+		return BinarySearch(array_lists, nBegin, nMid - 1, target, compareCount);
+	else
+		return BinarySearch(array_lists, nMid + 1, nEnd, target, compareCount);
+}
+
+static Element encode(Element a, Element b)
+{
+	return a + b;
+}
+
+static Element decode(Element a, Element b)
+{
+	return a - b;
+}
+
+
+/* 类 */
+class Receiver
+{
+private:
+	Element X[n] = { NULL };
+	Element k = NULL;
+	Element X_c[beta] = { NULL };
+	Element Z[beta] = { NULL };
+	Element W[beta] = { NULL };
+	Element U[beta] = { NULL };
+	Element Z_pi[beta] = { NULL };
+	vector<Element> intersection{};
+
+public:
+	void input_X()
+	{
+		getInput(this->X, n);
+		return;
+	}
+	void auto_input_X()
+	{
+		vector<Element> v;
+		while (v.size() < n)
+		{
+			Element tmp = getRandom();
+			if (find(v.begin(), v.end(), tmp) == v.end())
+				v.push_back(tmp);
+		}
+		for (int i = 0; i < n; ++i)
+			this->X[i] = v[i];
+		return;
+	}
+	void choose_k()
+	{
+		this->k = getRandom();
+		return;
+	}
+	Element send_k() const
+	{
+		return this->k;
+	}
+	void hash_X_to_X_c()
+	{
+		for (int i = 0; i < n; ++i)
+		{
+			int index = r_i(this->X[i], 1) % beta;
+			if (0 != this->X_c[index])// already exist
+			{
+				int new_index = r_i(this->X_c[index], 2) % beta;
+				if (0 != this->X_c[new_index])// still already exist
+					;// abundant
+				else
+					this->X_c[new_index] = this->X_c[index];
+			}
+			else
+				this->X_c[index] = X[i];
+		}
+		return;
+	}
+	Element* help_compute_Z_pi()
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z_pi[i] = this->X_c[pi(i)] ^ this->Z[i];
+		return this->Z_pi;
+	}
+#ifdef _DEBUG
+	void printArray()
+	{
+		cout << "X = { " << this->X[0];
+		for (int i = 1; i < n; ++i)
+			cout << ", " << this->X[i];
+		cout << " }" << endl << endl;
+		cout << "X_c: " << endl;
+		for (int i = 0; i < beta; ++i)
+			if (this->X_c[i])
+				cout << "X_c[" << i << "] = " << this->X_c[i] << endl;
+		cout << endl;
+		return;
+	}
+#else
+	void printArray()
+	{
+		return;
+	}
+#endif
+	void obtain_Z()
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z[i] = this->X_c[i];
+		return;
+	}
+	Element* send_Z()
+	{
+		return this->Z;
+	}
+	void receive_W(Element* _W)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->W[i] = *(_W + i);
+		return;
+	}
+	void generate_U()
+	{
+		for (int i = 0; i < beta; ++i)
+			this->U[i] = getRandom();
+		return;
+	}
+	void printIntersection()
+	{
+		this->intersection.clear();
+		unsigned int comparation = 0;
+		qsort(this->W, beta, sizeof(Element), compare);
+		qsort(this->U, beta, sizeof(Element), compare);
+		for (int i = 0; i < beta; ++i)
+			if (this->W[i] && BinarySearch(this->U, 0, beta - 1, this->W[i], comparation))
+				this->intersection.push_back(this->W[i]);
+		if (this->intersection.size())
+		{
+#ifdef _DEBUG
+			cout << "| U ∩ W | = | { " << intersection[0];
+			for (size_t i = 1; i < this->intersection.size(); ++i)
+				cout << ", " << this->intersection[i];
+			cout << " } | = " << this->intersection.size() << endl;
+#else
+			cout << "| U ∩ W | = " << this->intersection.size() << endl;
+#endif
+		}
+		else
+			cout << "| U ∩ W | = 0" << endl;
+		return;
+	}
+	size_t printSize(bool isPow)
+	{
+		cout << "Timeof(R) = " << timerR * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Receiver) = " << sizeof(Receiver) << (isPow ? " KB" : " B") << endl;
+		cout << "sizeof(R) = " << sizeof(this) * baseNum << (isPow ? " MB" : " KB") << endl;
+		cout << "\tsizeof(R.X) = " << (isPow ? (sizeof(Element) * baseNum) << n : sizeof(this->X) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.k) = " << sizeof(this->k) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(R.X_c) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->X_c) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.Z) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.W) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->W) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.U) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->U) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.Z_pi) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z_pi) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.intersection) = " << (isPow ? sizeof(Element) * baseNum * this->intersection.size() : sizeof(this->intersection) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.*) = " << (isPow ? (sizeof(Element) * baseNum) * (1 + (1 << beta) + (1 << beta) + (1 << beta)) : (sizeof(this->k) + sizeof(this->Z) + sizeof(this->W) + sizeof(this->Z_pi)) * baseNum) << " B (*)" << endl;
+		return (sizeof(this->k) + sizeof(this->Z) + sizeof(this->W) + sizeof(this->Z_pi)) * baseNum;
+	}
+};
+Receiver R;
+
+class Sender
+{
+private:
+	Element Y[N] = { NULL };
+	Element k = NULL;
+	Element V[beta] = { NULL };
+	Element Z_pi[beta] = { NULL };
+	Element T[N] = { NULL };
+
+public:
+	void input_Y()
+	{
+		getInput(this->Y, N);
+	}
+	void auto_input_Y()
+	{
+		vector<Element> v;
+		while (v.size() < N)
+		{
+			Element tmp = getRandom();
+			if (find(v.begin(), v.end(), tmp) == v.end())
+				v.push_back(tmp);
+		}
+		for (int i = 0; i < N; ++i)
+			this->Y[i] = v[i];
+		return;
+	}
+	void receive_k(Element _k)
+	{
+		this->k = _k;
+		return;
+	}
+	void rand_V()
+	{
+		for (int i = 0; i < beta; ++i)
+			V[i] = this->k - rand();
+		return;
+	}
+	void compute_Z_pi(Element* Z)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z_pi[i] = *(Z + i);
+		return;
+	}
+	void compute_T()
+	{
+		for (int i = 0; i < N; ++i)
+		{
+			Element q_j = 0, I_i = 0;
+			for (int j = 0; j < gamma; ++j)
+			{
+				q_j = arcpi(r_i(this->Y[i], j) % beta);
+				I_i = this->Y[i] ^ this->Z_pi[q_j];
+			}
+			T[i] = encode(I_i, this->V[i % beta]);
+		}
+		return;
+	}
+	Element* send_T()
+	{
+		return this->T;
+	}
+	size_t printSize(bool isPow)
+	{
+		cout << "Timeof(S) = " << timerS * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Sender) = " << sizeof(Sender) << (isPow ? " KB" : " B") << endl;
+		cout << "sizeof(S) = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(S.Y) = " << (isPow ? (sizeof(Element) * baseNum) << N : sizeof(this->Y) * baseNum) << " B" << endl;
+		cout << "\tsizeof(S.k) = " << sizeof(this->k) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(S.V) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->V) * baseNum) << " B" << endl;
+		cout << "\tsizeof(S.Z_pi) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z_pi) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(S.T) = " << (isPow ? (sizeof(Element) * baseNum) << N : sizeof(this->T) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(S.*) = " << (isPow ? (sizeof(Element) * baseNum) * (1 + (1 << beta) + (1 << N)) : (sizeof(this->k) + sizeof(this->Z_pi) + sizeof(this->T)) * baseNum) << " B (*)" << endl;
+		return isPow ? (sizeof(Element) * baseNum) * (1 + (1 << beta) + (1 << N)) : (sizeof(this->k) + sizeof(this->Z_pi) + sizeof(this->T)) * baseNum;
+	}
+};
+Sender S;
+
+class Cloud
+{
+private:
+	Element Z[beta] = { NULL };
+	Element T[N] = { NULL };
+	Element W[beta] = { NULL };
+
+public:
+	void receive_Z(Element* _Z)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z[i] = *(_Z + i);
+		return;
+	}
+	void receive_T(Element* _T)
+	{
+		for (int i = 0; i < N; ++i)
+		{
+			this->T[i] = *(_T + i);
+			W[i % beta] = decode(this->T[i], this->Z[i % beta]);
+		}
+		return;
+	}
+	Element* send_W()
+	{
+		return this->W;
+	}
+	size_t printSize(bool isPow)
+	{
+		cout << "Timeof(C) = " << timerC * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Cloud) = " << sizeof(Cloud) << (isPow ? " KB" : " B") << endl;
+		cout << "sizeof(C) = " << sizeof(this) * baseNum << (isPow ? " MB" : " KB") << endl;
+		cout << "\tsizeof(C.Z) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(C.T) = " << (isPow ? (sizeof(Element) * baseNum) << N : sizeof(this->T) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(C.W) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->W) * baseNum) << " B" << endl;
+		cout << "\tsizeof(C.*) = " << (isPow ? (sizeof(Element) * baseNum) * ((1 << beta) + (1 << N)) : (sizeof(this->Z) + sizeof(this->T)) * baseNum) << " B (*)" << endl;
+		return isPow ? (sizeof(Element) * baseNum) * ((1 << beta) + (1 << N)) : (sizeof(this->Z) + sizeof(this->T)) * baseNum;
+	}
+};
+Cloud C;
+
+
+/* 主函数 */
+static void initial(bool isAuto)
+{
+
+	init_hashpi();// setup pi
+	if (isAuto)
+	{
+		S.auto_input_Y();
+		R.auto_input_X();
+	}
+	else
+	{
+		cout << "Please input array Y with size " << N << ": " << endl;
+		S.input_Y();// Sender S has input Y
+		cout << endl;
+		cout << "Please input array X with size " << n << ": " << endl;
+		R.input_X();// Sender R has input X
+		cout << endl;
+	}
+	return;
+}
+
+static void setup()
+{
+	sub_start_time = clock();	R.choose_k();				sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;// The receiver chooses a random PRG key k
+	sub_start_time = clock();	S.receive_k(R.send_k());	sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time; timerS += (double)sub_end_time - sub_start_time;// k is sent to S
+	sub_start_time = clock();	S.rand_V();					sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time;// rand beta
+	return;
+}
+
+static void distribution()
+{
+	sub_start_time = clock();	R.hash_X_to_X_c(); 						sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;
+#ifdef _DEBUG
+	sub_start_time = clock();	R.printArray(); 						sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;
+#endif
+	sub_start_time = clock();	R.obtain_Z(); 							sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;// ss1
+	sub_start_time = clock();	S.compute_Z_pi(R.help_compute_Z_pi()); 	sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time; timerS += (double)sub_end_time - sub_start_time;// ss2
+	sub_start_time = clock();	C.receive_Z(R.send_Z());				sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time; timerC += (double)sub_end_time - sub_start_time;// Z is sent to C
+	return;
+}
+
+static void computation()
+{
+	sub_start_time = clock();	S.compute_T();				sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time;
+	sub_start_time = clock();	C.receive_T(S.send_T());	sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time; timerC += (double)sub_end_time - sub_start_time;// T is sent to C
+	sub_start_time = clock();	R.receive_W(C.send_W());	sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time; timerC += (double)sub_end_time - sub_start_time;// W is sent to R
+	sub_start_time = clock();	R.generate_U();				sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;
+	sub_start_time = clock();	R.printIntersection();		sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;
+	return;
+}
+
+
+
+/* main 函数 */
+static void test()
+{
+	time_t t;
+	srand((unsigned int)time(&t));
+	initial(true);
+	setup();
+	distribution();
+	computation();
+	return;
+}
+
+int main(int argc, char* argv[])
+{
+	Parser parser(argc, argv, "PSI-CA");
+	const ParserOptions options = parser.parse();
+	if (options.flag <= 0)
+	{
+		return finishExecution(options.waitingTime, options.decimalPlace, options.flag == 0 ? EXIT_SUCCESS : -1);
+	}
+
+	configuredRunCount = options.runCount;
+	double elapsedCpuMilliseconds = 0.0;
+	std::uint64_t spaceBytes = 0U;
+	{
+		ScopedOutputSilencer silencer(cout, options.quiet);
+		const clock_t start_time = clock();
+		for (std::size_t i = 0U; i < options.runCount; ++i)
+		{
+			cout << "/**************************************** Time: " << i + 1U << " ****************************************/" << endl;
+			test();
+			cout << endl << endl;
+		}
+		const clock_t end_time = clock();
+		elapsedCpuMilliseconds = static_cast<double>(end_time - start_time) * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / static_cast<double>(options.runCount);
+		cout << endl;
+		cout << "/**************************************** PSI-CA ****************************************/" << endl;
+		cout << "kBit = " << kBit << "\t\tgamma = " << gamma << endl;
+		cout << "N = 2 ** " << N << "\t\tn = 2 ** " << n << "\t\tbeta = [2 ** " << (log2(1.27) + n) << "]" << endl;
+		cout << "Time: " << elapsedCpuMilliseconds << " ms" << endl;
+		spaceBytes = static_cast<std::uint64_t>(R.printSize(true) + S.printSize(true) + C.printSize(true));
+		cout << "sizeof(*) = " << spaceBytes << " B (*)" << endl << endl;
+	}
+
+	const double divisor = static_cast<double>(options.runCount);
+	const double receiverCpuMilliseconds = timerR * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double senderCpuMilliseconds = timerS * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double cloudCpuMilliseconds = timerC * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	Saver saver(
+		options.outputPath,
+		{"scheme", "kBit", "N", "n", "beta", "gamma", "runCount", "elapsedCpuMilliseconds", "receiverCpuMilliseconds", "senderCpuMilliseconds", "cloudCpuMilliseconds", "spaceBytes"},
+		options.decimalPlace,
+		options.overwriteConfirmed);
+	const SaverRow row = {
+		std::string("PSI-CA"), std::uint64_t{kBit}, std::uint64_t{N}, std::uint64_t{n}, std::uint64_t{beta}, std::uint64_t{gamma},
+		static_cast<std::uint64_t>(options.runCount), elapsedCpuMilliseconds, receiverCpuMilliseconds,
+		senderCpuMilliseconds, cloudCpuMilliseconds, spaceBytes};
+	const int exitCode = saver.save({row}) ? EXIT_SUCCESS : EXIT_FAILURE;
+	return finishExecution(options.waitingTime, options.decimalPlace, exitCode);
+}

--- a/PSI-CA/PSI-CA.cpp
+++ b/PSI-CA/PSI-CA.cpp
@@ -1,6 +1,7 @@
 ﻿#include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cstring>
 
 #include "ParserSaver.hpp"
 #ifndef _PSICA_H

--- a/PSI-CA/ParserSaver.hpp
+++ b/PSI-CA/ParserSaver.hpp
@@ -1,0 +1,1254 @@
+#ifndef PSI_CA_PARSER_SAVER_HPP
+#define PSI_CA_PARSER_SAVER_HPP
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <cerrno>
+#include <charconv>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <iomanip>
+#include <initializer_list>
+#include <iostream>
+#include <limits>
+#include <locale>
+#include <sstream>
+#include <string>
+#include <streambuf>
+#include <system_error>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#if defined(_WIN32)
+#error "PSI-CA C++ programs require a POSIX platform."
+#else
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+struct ParserOptions
+{
+	int flag = 1;
+	std::string encoding = "utf-8";
+	std::filesystem::path outputPath;
+	int decimalPlace = 9;
+	bool quiet = false;
+	std::size_t runCount = 10U;
+	double waitingTime = std::numeric_limits<double>::infinity();
+	bool overwriteConfirmed = false;
+};
+
+using SaverValue = std::variant<std::monostate, bool, std::int64_t, std::uint64_t, double, std::string>;
+using SaverRow = std::vector<SaverValue>;
+
+namespace parser_saver_detail
+{
+	inline std::string lower(std::string value)
+	{
+		std::transform(
+			value.begin(),
+			value.end(),
+			value.begin(),
+			[](const unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+		return value;
+	}
+
+	inline bool matches(const std::string &argument, const std::initializer_list<const char *> aliases)
+	{
+		const std::string normalized = lower(argument);
+		return std::any_of(
+			aliases.begin(),
+			aliases.end(),
+			[&normalized](const char *alias)
+			{
+				return normalized == alias;
+			});
+	}
+
+	inline bool parseNonnegativeInteger(const std::string &text, std::uint64_t &value)
+	{
+		if (text.empty() || text.front() == '-')
+		{
+			return false;
+		}
+		const char *const begin = text.data();
+		const char *const end = begin + text.size();
+		const std::from_chars_result result = std::from_chars(begin, end, value);
+		return result.ec == std::errc() && result.ptr == end;
+	}
+
+	inline bool parseNonnegativeDouble(const std::string &text, double &value)
+	{
+		const std::string normalized = lower(text);
+		if (normalized == "inf" || normalized == "+inf" || normalized == "infinity" || normalized == "+infinity")
+		{
+			value = std::numeric_limits<double>::infinity();
+			return true;
+		}
+		std::istringstream input(text);
+		input.imbue(std::locale::classic());
+		input >> std::noskipws >> value;
+		if (!input || std::isnan(value) || value < 0.0)
+		{
+			return false;
+		}
+		char remaining = '\0';
+		return !(input >> remaining) && input.eof();
+	}
+
+	inline bool isProtectedExtension(const std::filesystem::path &path)
+	{
+		static const std::vector<std::string> extensions = {
+			".asm", ".bat", ".c", ".cmd", ".cpp", ".cs", ".go", ".h", ".hpp", ".ipynb", ".jar",
+			".java", ".js", ".kt", ".lua", ".m", ".o", ".php", ".ps1", ".py", ".r", ".rb", ".rs",
+			".s", ".sh", ".sql"};
+		const std::string extension = lower(path.extension().string());
+		return std::find(extensions.begin(), extensions.end(), extension) != extensions.end();
+	}
+
+	inline bool isNotFoundError(const std::error_code &error)
+	{
+		return error == std::errc::no_such_file_or_directory;
+	}
+
+	inline bool writeAllToDescriptor(const int descriptor, const std::string &content, std::error_code &error)
+	{
+		error.clear();
+		std::size_t offset = 0U;
+		while (offset < content.size())
+		{
+			const std::size_t remaining = content.size() - offset;
+			const std::size_t maximumWrite = static_cast<std::size_t>(std::numeric_limits<ssize_t>::max());
+			const std::size_t requested = std::min(remaining, maximumWrite);
+			const ssize_t written = ::write(descriptor, content.data() + offset, requested);
+			if (written > 0)
+			{
+				offset += static_cast<std::size_t>(written);
+				continue;
+			}
+			if (written < 0 && errno == EINTR)
+			{
+				continue;
+			}
+			error = std::error_code(written == 0 ? EIO : errno, std::generic_category());
+			return false;
+		}
+		return true;
+	}
+
+	inline bool closeDescriptorChecked(const int descriptor, std::error_code &error)
+	{
+		error.clear();
+		if (::close(descriptor) == 0)
+		{
+			return true;
+		}
+		error = std::error_code(errno, std::generic_category());
+		return false;
+	}
+
+	inline bool isExecutablePathCandidate(const std::filesystem::path &path)
+	{
+		std::error_code error;
+		const std::filesystem::file_status status = std::filesystem::status(path, error);
+		if (error || status.type() != std::filesystem::file_type::regular)
+		{
+			return false;
+		}
+		return ::access(path.c_str(), X_OK) == 0;
+	}
+
+	inline std::filesystem::path resolveExecutableDirectory(
+		const std::filesystem::path &argvZero,
+		const std::filesystem::path &currentDirectory,
+		const std::string &searchPath,
+		const char pathSeparator)
+	{
+		const std::filesystem::path normalizedCurrent = currentDirectory.lexically_normal();
+		if (argvZero.empty())
+		{
+			return normalizedCurrent;
+		}
+		if (argvZero.is_absolute())
+		{
+			return argvZero.lexically_normal().parent_path();
+		}
+		if (argvZero.has_parent_path())
+		{
+			return (normalizedCurrent / argvZero).lexically_normal().parent_path();
+		}
+
+		std::size_t entryStart = 0U;
+		while (entryStart <= searchPath.size())
+		{
+			const std::size_t separator = searchPath.find(pathSeparator, entryStart);
+			const std::size_t entryLength = separator == std::string::npos ? std::string::npos : separator - entryStart;
+			const std::string entry = searchPath.substr(entryStart, entryLength);
+			std::filesystem::path directory = entry.empty() ? normalizedCurrent : std::filesystem::path(entry);
+			if (directory.is_relative())
+			{
+				directory = normalizedCurrent / directory;
+			}
+			const std::filesystem::path candidate = (directory / argvZero).lexically_normal();
+			if (isExecutablePathCandidate(candidate))
+			{
+				return candidate.parent_path();
+			}
+			if (separator == std::string::npos)
+			{
+				break;
+			}
+			entryStart = separator + 1U;
+		}
+		return normalizedCurrent;
+	}
+
+	inline std::string formatValue(const SaverValue &value, const int decimalPlace)
+	{
+		return std::visit(
+			[decimalPlace](const auto &item) -> std::string
+			{
+				using ValueType = std::decay_t<decltype(item)>;
+				if constexpr (std::is_same_v<ValueType, std::monostate>)
+				{
+					return {};
+				}
+				else if constexpr (std::is_same_v<ValueType, bool>)
+				{
+					return item ? "true" : "false";
+				}
+				else if constexpr (std::is_same_v<ValueType, std::int64_t> || std::is_same_v<ValueType, std::uint64_t>)
+				{
+					return std::to_string(item);
+				}
+				else if constexpr (std::is_same_v<ValueType, double>)
+				{
+					std::ostringstream output;
+					output.imbue(std::locale::classic());
+					output << std::fixed << std::setprecision(decimalPlace) << item;
+					return output.str();
+				}
+				else
+				{
+					return item;
+				}
+			},
+			value);
+	}
+
+	inline std::string quoteDelimited(const std::string &value, const char delimiter)
+	{
+		if (value.find_first_of(std::string{delimiter} + "\"\r\n") == std::string::npos)
+		{
+			return value;
+		}
+		std::string quoted;
+		quoted.reserve(value.size() + 2U);
+		quoted.push_back('"');
+		for (const char character : value)
+		{
+			if (character == '"')
+			{
+				quoted.push_back('"');
+			}
+			quoted.push_back(character);
+		}
+		quoted.push_back('"');
+		return quoted;
+	}
+
+	inline std::string escapeText(const std::string &value)
+	{
+		std::string escaped;
+		escaped.reserve(value.size());
+		for (const char character : value)
+		{
+			switch (character)
+			{
+			case '\\':
+				escaped += "\\\\";
+				break;
+			case '\t':
+				escaped += "\\t";
+				break;
+			case '\r':
+				escaped += "\\r";
+				break;
+			case '\n':
+				escaped += "\\n";
+				break;
+			default:
+				escaped.push_back(character);
+				break;
+			}
+		}
+		return escaped;
+	}
+
+	class StreamStateGuard
+	{
+	public:
+		explicit StreamStateGuard(std::ostream &stream)
+			: stream_(stream),
+			  flags_(stream.flags()),
+			  precision_(stream.precision()),
+			  fill_(stream.fill()),
+			  width_(stream.width())
+		{
+		}
+
+		~StreamStateGuard()
+		{
+			stream_.flags(flags_);
+			stream_.precision(precision_);
+			stream_.fill(fill_);
+			stream_.width(width_);
+		}
+
+		StreamStateGuard(const StreamStateGuard &) = delete;
+		StreamStateGuard &operator=(const StreamStateGuard &) = delete;
+
+	private:
+		std::ostream &stream_;
+		std::ios::fmtflags flags_;
+		std::streamsize precision_;
+		char fill_;
+		std::streamsize width_;
+	};
+
+}
+
+class ScopedOutputSilencer
+{
+public:
+	explicit ScopedOutputSilencer(std::ostream &stream, const bool enabled)
+		: stream_(stream), originalBuffer_(nullptr)
+	{
+		if (enabled)
+		{
+			originalBuffer_ = stream_.rdbuf(&sink_);
+		}
+	}
+
+	~ScopedOutputSilencer()
+	{
+		if (originalBuffer_ != nullptr)
+		{
+			stream_.rdbuf(originalBuffer_);
+		}
+	}
+
+	ScopedOutputSilencer(const ScopedOutputSilencer &) = delete;
+	ScopedOutputSilencer &operator=(const ScopedOutputSilencer &) = delete;
+
+private:
+	class DiscardBuffer : public std::streambuf
+	{
+	protected:
+		int_type overflow(const int_type character) override
+		{
+			return traits_type::not_eof(character);
+		}
+
+		std::streamsize xsputn(const char *, const std::streamsize count) override
+		{
+			return count;
+		}
+	};
+
+	std::ostream &stream_;
+	std::streambuf *originalBuffer_;
+	DiscardBuffer sink_;
+};
+
+class LegacyRandGenerator
+{
+public:
+	using result_type = unsigned int;
+
+	static constexpr result_type min()
+	{
+		return 0U;
+	}
+
+	static constexpr result_type max()
+	{
+		return static_cast<result_type>(RAND_MAX);
+	}
+
+	result_type operator()() const
+	{
+		return static_cast<result_type>(std::rand());
+	}
+};
+
+template <typename RandomAccessIterator>
+void legacyRandomShuffle(RandomAccessIterator first, RandomAccessIterator last)
+{
+	std::shuffle(first, last, LegacyRandGenerator{});
+}
+
+class Parser
+{
+public:
+	static constexpr int MAX_DECIMAL_PLACE = 18;
+
+	Parser(
+		const int argc,
+		char *const argv[],
+		std::string schemeName,
+		const bool interactiveInput = false,
+		std::istream &input = std::cin,
+		std::ostream &output = std::cout,
+		std::ostream &error = std::cerr)
+		: schemeName_(schemeName.empty() ? "output" : std::move(schemeName)),
+		  interactiveInput_(interactiveInput),
+		  input_(input),
+		  output_(output),
+		  error_(error)
+	{
+		if (argc > 0 && argv != nullptr)
+		{
+			arguments_.reserve(static_cast<std::size_t>(argc));
+			for (int index = 0; index < argc; ++index)
+			{
+				arguments_.emplace_back(argv[index] == nullptr ? "" : argv[index]);
+			}
+		}
+		const std::filesystem::path executable = arguments_.empty() ? std::filesystem::path{} : std::filesystem::path(arguments_.front());
+		std::error_code errorCode;
+		const std::filesystem::path currentDirectory = std::filesystem::current_path(errorCode);
+		if (errorCode)
+		{
+			initializationError_ = "Could not determine the current directory: " + errorCode.message();
+			executableDirectory_ = ".";
+			return;
+		}
+		const char *const pathEnvironment = std::getenv("PATH");
+#if defined(_WIN32)
+		constexpr char pathSeparator = ';';
+#else
+		constexpr char pathSeparator = ':';
+#endif
+		executableDirectory_ = parser_saver_detail::resolveExecutableDirectory(
+			executable,
+			currentDirectory,
+			pathEnvironment == nullptr ? std::string{} : std::string(pathEnvironment),
+			pathSeparator);
+	}
+
+	ParserOptions parse()
+	{
+		if (parsed_)
+		{
+			return options_;
+		}
+		parsed_ = true;
+		options_.outputPath = executableDirectory_ / defaultFilename();
+		if (!initializationError_.empty())
+		{
+			return invalid(initializationError_);
+		}
+
+		for (std::size_t index = 1U; index < arguments_.size(); ++index)
+		{
+			const std::string &argument = arguments_[index];
+			if (parser_saver_detail::matches(argument, {"h", "/h", "-h", "help", "/help", "--help"}))
+			{
+				options_.flag = 0;
+				printHelp();
+				return options_;
+			}
+			if (parser_saver_detail::matches(argument, {"q", "/q", "-q", "quiet", "/quiet", "--quiet"}))
+			{
+				options_.quiet = true;
+				continue;
+			}
+			if (parser_saver_detail::matches(argument, {"y", "/y", "-y", "yes", "/yes", "--yes"}))
+			{
+				options_.overwriteConfirmed = true;
+				continue;
+			}
+
+			const bool encodingOption = parser_saver_detail::matches(argument, {"e", "/e", "-e", "encoding", "/encoding", "--encoding"});
+			const bool outputOption = parser_saver_detail::matches(argument, {"o", "/o", "-o", "output", "/output", "--output"});
+			const bool placeOption = parser_saver_detail::matches(argument, {"p", "/p", "-p", "place", "/place", "--place"});
+			const bool runOption = parser_saver_detail::matches(argument, {"r", "/r", "-r", "run", "/run", "--run"});
+			const bool timeOption = parser_saver_detail::matches(argument, {"t", "/t", "-t", "time", "/time", "--time"});
+			if (!encodingOption && !outputOption && !placeOption && !runOption && !timeOption)
+			{
+				return invalid("Unknown argument: " + argument);
+			}
+			if (index + 1U >= arguments_.size())
+			{
+				return invalid("Missing value for argument: " + argument);
+			}
+			const std::string value = arguments_[++index];
+			if (encodingOption)
+			{
+				const std::string encoding = parser_saver_detail::lower(value);
+				if (encoding != "utf-8" && encoding != "utf8")
+				{
+					return invalid("Unsupported encoding: " + value + "; only UTF-8 is supported.");
+				}
+				options_.encoding = "utf-8";
+			}
+			else if (outputOption)
+			{
+				if (value.empty())
+				{
+					options_.outputPath.clear();
+				}
+				else
+				{
+					options_.outputPath = resolveOutputPath(value);
+				}
+			}
+			else if (placeOption)
+			{
+				if (!parsePlace(value))
+				{
+					return invalid("Invalid decimal place: " + value);
+				}
+			}
+			else if (runOption)
+			{
+				std::uint64_t runCount = 0U;
+				if (!parser_saver_detail::parseNonnegativeInteger(value, runCount) || runCount == 0U || runCount > std::numeric_limits<std::size_t>::max())
+				{
+					return invalid("Run count must be a positive integer: " + value);
+				}
+				options_.runCount = static_cast<std::size_t>(runCount);
+			}
+			else
+			{
+				double waitingTime = 0.0;
+				if (!parser_saver_detail::parseNonnegativeDouble(value, waitingTime))
+				{
+					return invalid("Waiting time must be nonnegative: " + value);
+				}
+				options_.waitingTime = waitingTime;
+			}
+		}
+
+		if (parser_saver_detail::isProtectedExtension(options_.outputPath))
+		{
+			options_.outputPath.replace_extension(".csv");
+		}
+		options_.outputPath = options_.outputPath.lexically_normal();
+		std::filesystem::file_status outputStatus(std::filesystem::file_type::not_found);
+		if (!options_.outputPath.empty())
+		{
+			std::error_code inspectionError;
+			outputStatus = std::filesystem::symlink_status(options_.outputPath, inspectionError);
+			if (inspectionError && !parser_saver_detail::isNotFoundError(inspectionError))
+			{
+				return invalid("Could not inspect output path " + options_.outputPath.string() + ": " + inspectionError.message());
+			}
+			if (parser_saver_detail::isNotFoundError(inspectionError))
+			{
+				outputStatus = std::filesystem::file_status(std::filesystem::file_type::not_found);
+			}
+		}
+		if (outputStatus.type() != std::filesystem::file_type::not_found && !options_.overwriteConfirmed)
+		{
+			if (!interactiveInput_)
+			{
+				return invalid("Output file already exists; use -y to overwrite it.");
+			}
+			output_ << "Output file already exists: " << options_.outputPath << "\nOverwrite it? [y/N] " << std::flush;
+			std::string answer;
+			if (!std::getline(input_, answer) || (parser_saver_detail::lower(answer) != "y" && parser_saver_detail::lower(answer) != "yes"))
+			{
+				return invalid("Overwrite was not confirmed.");
+			}
+			options_.overwriteConfirmed = true;
+		}
+		return options_;
+	}
+
+	const ParserOptions &options() const
+	{
+		return options_;
+	}
+
+private:
+	std::string defaultFilename() const
+	{
+		return schemeName_ + ".csv";
+	}
+
+	ParserOptions invalid(const std::string &message)
+	{
+		options_.flag = -1;
+		error_ << "Error: " << message << '\n';
+		return options_;
+	}
+
+	bool parsePlace(const std::string &text)
+	{
+		const std::string normalized = parser_saver_detail::lower(text);
+		static const std::vector<std::pair<std::string, int>> translations = {
+			{"s", 0}, {"second", 0}, {"ms", 3}, {"millisecond", 3}, {"microsecond", 6},
+			{"ns", 9}, {"nanosecond", 9}, {"ps", 12}, {"picosecond", 12}, {"fs", 15}, {"femtosecond", 15}};
+		const auto translation = std::find_if(
+			translations.begin(),
+			translations.end(),
+			[&normalized](const std::pair<std::string, int> &item)
+			{
+				return item.first == normalized;
+			});
+		if (translation != translations.end())
+		{
+			options_.decimalPlace = translation->second;
+			return true;
+		}
+		std::uint64_t place = 0U;
+		if (!parser_saver_detail::parseNonnegativeInteger(text, place) || place > static_cast<std::uint64_t>(MAX_DECIMAL_PLACE))
+		{
+			return false;
+		}
+		options_.decimalPlace = static_cast<int>(place);
+		return true;
+	}
+
+	void printHelp()
+	{
+		output_ << "Usage: " << schemeName_ << " [options]\n"
+			<< "  -e, --encoding UTF-8\n"
+			<< "  -o, --output PATH\n"
+			<< "  -p, --place PLACES\n"
+			<< "  -q, --quiet\n"
+			<< "  -r, --run COUNT\n"
+			<< "  -t, --time SECONDS\n"
+			<< "  -y, --yes\n";
+	}
+
+	std::filesystem::path resolveOutputPath(const std::string &value) const
+	{
+		std::filesystem::path path(value);
+		if (path.is_relative())
+		{
+			path = executableDirectory_ / path;
+		}
+		const bool trailingSeparator = !value.empty() && (value.back() == '/' || value.back() == '\\');
+		std::error_code error;
+		const bool directory = trailingSeparator || std::filesystem::is_directory(path, error);
+		if (directory)
+		{
+			path /= defaultFilename();
+		}
+		return path.lexically_normal();
+	}
+
+	std::vector<std::string> arguments_;
+	std::string schemeName_;
+	std::filesystem::path executableDirectory_;
+	std::string initializationError_;
+	bool interactiveInput_;
+	std::istream &input_;
+	std::ostream &output_;
+	std::ostream &error_;
+	ParserOptions options_;
+	bool parsed_ = false;
+};
+
+class Saver
+{
+public:
+	Saver(
+		std::filesystem::path outputPath,
+		std::vector<std::string> columns = {},
+		const int decimalPlace = 9,
+		const bool overwriteAuthorized = false,
+		std::ostream &output = std::cout,
+		std::ostream &error = std::cerr)
+		: outputPath_(std::move(outputPath)),
+		  columns_(std::move(columns)),
+		  decimalPlace_(decimalPlace < 0 ? 9 : std::min(decimalPlace, Parser::MAX_DECIMAL_PLACE)),
+		  overwriteAuthorized_(overwriteAuthorized),
+		  output_(output),
+		  error_(error)
+	{
+	}
+
+	bool save(const std::vector<SaverRow> &rows) const
+	{
+		if (outputPath_.empty())
+		{
+			writeTable(output_, rows);
+			return static_cast<bool>(output_);
+		}
+		if (parser_saver_detail::isProtectedExtension(outputPath_))
+		{
+			error_ << "Error: refusing protected output extension for " << outputPath_ << '\n';
+			return false;
+		}
+		const std::filesystem::path parent = outputPath_.parent_path().empty() ? std::filesystem::path(".") : outputPath_.parent_path();
+		std::error_code filesystemError;
+		std::filesystem::create_directories(parent, filesystemError);
+		if (filesystemError)
+		{
+			error_ << "Error: could not create output directory " << parent << ": " << filesystemError.message() << '\n';
+			return false;
+		}
+		const int openedParent = ::open(parent.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+		if (openedParent < 0)
+		{
+			error_ << "Error: could not open output directory " << parent << ": " << std::error_code(errno, std::generic_category()).message() << '\n';
+			return false;
+		}
+		DescriptorGuard parentDescriptor(openedParent, error_, "output parent directory");
+		struct stat parentIdentity = {};
+		if (::fstat(parentDescriptor.get(), &parentIdentity) != 0 || !S_ISDIR(parentIdentity.st_mode))
+		{
+			error_ << "Error: opened output parent is not a directory.\n";
+			return false;
+		}
+		const std::string targetName = outputPath_.filename().string();
+		if (targetName.empty() || targetName == "." || targetName == "..")
+		{
+			error_ << "Error: invalid output filename for " << outputPath_ << '\n';
+			return false;
+		}
+		bool targetExisted = false;
+		if (!inspectTarget(parentDescriptor.get(), targetName, targetExisted))
+		{
+			return false;
+		}
+		if (targetExisted && !overwriteAuthorized_)
+		{
+			error_ << "Error: refusing to overwrite existing output file " << outputPath_ << '\n';
+			return false;
+		}
+
+		const std::string extension = parser_saver_detail::lower(outputPath_.extension().string());
+		bool usedFallback = false;
+		std::string content;
+		try
+		{
+			std::ostringstream formattedOutput;
+			if (extension == ".csv")
+			{
+				writeDelimited(formattedOutput, rows, ',');
+			}
+			else if (extension == ".tsv")
+			{
+				writeDelimited(formattedOutput, rows, '\t');
+			}
+			else if (extension == ".txt")
+			{
+				writeText(formattedOutput, rows);
+			}
+			else
+			{
+				writeText(formattedOutput, rows);
+				usedFallback = true;
+			}
+			if (!formattedOutput)
+			{
+				error_ << "Error: could not format output for " << outputPath_ << '\n';
+				return false;
+			}
+			content = formattedOutput.str();
+		}
+		catch (const std::exception &exception)
+		{
+			error_ << "Error: could not format output for " << outputPath_ << ": " << exception.what() << '\n';
+			return false;
+		}
+		catch (...)
+		{
+			error_ << "Error: could not format output for " << outputPath_ << '\n';
+			return false;
+		}
+
+		WorkspaceIdentity workspace;
+		if (!createWorkspace(parentDescriptor.get(), workspace))
+		{
+			return false;
+		}
+		WorkspaceGuard workspaceGuard(parentDescriptor.get(), workspace, error_);
+		if (!isPrivateWorkspaceIdentity(workspace))
+		{
+			error_ << "Error: process umask prevented creation of an owner-owned mode-0700 output workspace.\n";
+			return false;
+		}
+		workspace.descriptor = ::openat(parentDescriptor.get(), workspace.name.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+		if (workspace.descriptor < 0)
+		{
+			error_ << "Error: could not open private output workspace: " << std::error_code(errno, std::generic_category()).message() << '\n';
+			return false;
+		}
+		struct stat openedWorkspace = {};
+		if (::fstat(workspace.descriptor, &openedWorkspace) != 0
+			|| openedWorkspace.st_dev != workspace.device
+			|| openedWorkspace.st_ino != workspace.inode
+			|| openedWorkspace.st_uid != workspace.owner
+			|| openedWorkspace.st_mode != workspace.mode)
+		{
+			error_ << "Error: private output workspace identity changed while opening.\n";
+			return false;
+		}
+		const int openedContent = ::openat(
+			workspace.descriptor,
+			"content.tmp",
+			O_CREAT | O_EXCL | O_NOFOLLOW | O_WRONLY | O_CLOEXEC,
+			S_IRUSR | S_IWUSR);
+		if (openedContent < 0)
+		{
+			error_ << "Error: could not create temporary output content: " << std::error_code(errno, std::generic_category()).message() << '\n';
+			return false;
+		}
+		DescriptorGuard contentDescriptor(openedContent, error_, "temporary output content");
+		struct stat contentIdentity = {};
+		if (::fstat(contentDescriptor.get(), &contentIdentity) != 0
+			|| !S_ISREG(contentIdentity.st_mode)
+			|| contentIdentity.st_uid != ::geteuid()
+			|| (contentIdentity.st_mode & 0777) != 0600)
+		{
+			error_ << "Error: temporary output content is not an owner-only regular file.\n";
+			return false;
+		}
+		std::error_code writeError;
+		if (!parser_saver_detail::writeAllToDescriptor(contentDescriptor.get(), content, writeError))
+		{
+			error_ << "Error: could not write temporary output content: " << writeError.message() << '\n';
+			return false;
+		}
+		const int contentToClose = contentDescriptor.release();
+		std::error_code closeError;
+		if (!parser_saver_detail::closeDescriptorChecked(contentToClose, closeError))
+		{
+			error_ << "Error: could not close temporary output content: " << closeError.message() << '\n';
+			return false;
+		}
+		if (!inspectWorkspaceContent(workspace, contentIdentity))
+		{
+			return false;
+		}
+
+		bool targetStillExists = false;
+		if (!inspectTarget(parentDescriptor.get(), targetName, targetStillExists))
+		{
+			return false;
+		}
+		if (targetStillExists != targetExisted)
+		{
+			error_ << "Error: output target changed while saving: " << outputPath_ << '\n';
+			return false;
+		}
+		if (!publishTemporaryFile(parentDescriptor.get(), workspace.descriptor, targetName, targetExisted))
+		{
+			return false;
+		}
+		if (!workspaceGuard.cleanup())
+		{
+			error_ << "Error: output was published but its private workspace could not be removed safely.\n";
+			return false;
+		}
+		const int parentToClose = parentDescriptor.release();
+		if (!parser_saver_detail::closeDescriptorChecked(parentToClose, closeError))
+		{
+			error_ << "Error: output was published but its parent directory descriptor could not be closed: " << closeError.message() << '\n';
+			return false;
+		}
+		if (usedFallback)
+		{
+			output_ << "Saved TXT content to " << outputPath_ << " because its extension is unsupported.\n";
+		}
+		return true;
+	}
+
+private:
+	class DescriptorGuard
+	{
+	public:
+		DescriptorGuard(const int descriptor, std::ostream &error, std::string description)
+			: descriptor_(descriptor), error_(error), description_(std::move(description))
+		{
+		}
+
+		~DescriptorGuard()
+		{
+			if (descriptor_ >= 0)
+			{
+				std::error_code closeError;
+				const int descriptor = descriptor_;
+				descriptor_ = -1;
+				if (!parser_saver_detail::closeDescriptorChecked(descriptor, closeError))
+				{
+					error_ << "Error: could not close " << description_ << ": " << closeError.message() << '\n';
+				}
+			}
+		}
+
+		DescriptorGuard(const DescriptorGuard &) = delete;
+		DescriptorGuard &operator=(const DescriptorGuard &) = delete;
+
+		int get() const
+		{
+			return descriptor_;
+		}
+
+		int release()
+		{
+			const int descriptor = descriptor_;
+			descriptor_ = -1;
+			return descriptor;
+		}
+
+	private:
+		int descriptor_;
+		std::ostream &error_;
+		std::string description_;
+	};
+
+	struct WorkspaceIdentity
+	{
+		std::string name;
+		int descriptor = -1;
+		dev_t device = 0;
+		ino_t inode = 0;
+		uid_t owner = 0;
+		mode_t mode = 0;
+	};
+
+	class WorkspaceGuard
+	{
+	public:
+		WorkspaceGuard(const int parentDescriptor, WorkspaceIdentity &workspace, std::ostream &error)
+			: parentDescriptor_(parentDescriptor), workspace_(workspace), error_(error)
+		{
+		}
+
+		~WorkspaceGuard()
+		{
+			if (!cleanup())
+			{
+				error_ << "Error: private output workspace cleanup failed; a verified workspace may remain.\n";
+			}
+		}
+
+		WorkspaceGuard(const WorkspaceGuard &) = delete;
+		WorkspaceGuard &operator=(const WorkspaceGuard &) = delete;
+
+		bool cleanup()
+		{
+			if (cleaned_)
+			{
+				return cleanupSucceeded_;
+			}
+			cleaned_ = true;
+			cleanupSucceeded_ = true;
+			if (workspace_.descriptor >= 0)
+			{
+				if (::unlinkat(workspace_.descriptor, "content.tmp", 0) != 0 && errno != ENOENT)
+				{
+					cleanupSucceeded_ = false;
+				}
+				std::error_code closeError;
+				const int descriptor = workspace_.descriptor;
+				workspace_.descriptor = -1;
+				if (!parser_saver_detail::closeDescriptorChecked(descriptor, closeError))
+				{
+					cleanupSucceeded_ = false;
+				}
+			}
+			struct stat current = {};
+			if (::fstatat(parentDescriptor_, workspace_.name.c_str(), &current, AT_SYMLINK_NOFOLLOW) != 0)
+			{
+				if (errno != ENOENT)
+				{
+					cleanupSucceeded_ = false;
+				}
+				return cleanupSucceeded_;
+			}
+			const bool sameDirectory = S_ISDIR(current.st_mode)
+				&& current.st_dev == workspace_.device
+				&& current.st_ino == workspace_.inode
+				&& current.st_uid == workspace_.owner
+				&& current.st_mode == workspace_.mode;
+			if (!sameDirectory || ::unlinkat(parentDescriptor_, workspace_.name.c_str(), AT_REMOVEDIR) != 0)
+			{
+				cleanupSucceeded_ = false;
+			}
+			return cleanupSucceeded_;
+		}
+
+	private:
+		int parentDescriptor_;
+		WorkspaceIdentity &workspace_;
+		std::ostream &error_;
+		bool cleaned_ = false;
+		bool cleanupSucceeded_ = true;
+	};
+
+	bool inspectTarget(const int parentDescriptor, const std::string &targetName, bool &exists) const
+	{
+		struct stat target = {};
+		if (::fstatat(parentDescriptor, targetName.c_str(), &target, AT_SYMLINK_NOFOLLOW) != 0)
+		{
+			if (errno == ENOENT)
+			{
+				exists = false;
+				return true;
+			}
+			error_ << "Error: could not inspect output target " << outputPath_ << ": " << std::error_code(errno, std::generic_category()).message() << '\n';
+			return false;
+		}
+		exists = true;
+		if (S_ISLNK(target.st_mode))
+		{
+			error_ << "Error: refusing symlink output target " << outputPath_ << '\n';
+			return false;
+		}
+		if (!S_ISREG(target.st_mode))
+		{
+			error_ << "Error: refusing non-regular output target " << outputPath_ << '\n';
+			return false;
+		}
+		return true;
+	}
+
+	static bool isPrivateWorkspace(const struct stat &workspace)
+	{
+		return S_ISDIR(workspace.st_mode)
+			&& workspace.st_uid == ::geteuid()
+			&& (workspace.st_mode & 0777) == 0700;
+	}
+
+	static bool isPrivateWorkspaceIdentity(const WorkspaceIdentity &workspace)
+	{
+		return S_ISDIR(workspace.mode)
+			&& workspace.owner == ::geteuid()
+			&& (workspace.mode & 0777) == 0700;
+	}
+
+	bool createWorkspace(const int parentDescriptor, WorkspaceIdentity &workspace) const
+	{
+		static std::atomic<std::uint64_t> sequence{0U};
+		for (std::uint64_t attempt = 0U; attempt < 1000U; ++attempt)
+		{
+			const auto timestamp = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+			const std::uint64_t identifier = sequence.fetch_add(1U, std::memory_order_relaxed);
+			workspace.name = ".parser-saver-" + std::to_string(timestamp) + "-" + std::to_string(identifier) + ".tmpdir";
+			if (::mkdirat(parentDescriptor, workspace.name.c_str(), S_IRWXU) != 0)
+			{
+				if (errno != EEXIST)
+				{
+					error_ << "Error: could not create private output workspace: " << std::error_code(errno, std::generic_category()).message() << '\n';
+					return false;
+				}
+				continue;
+			}
+			struct stat pathIdentity = {};
+			if (::fstatat(parentDescriptor, workspace.name.c_str(), &pathIdentity, AT_SYMLINK_NOFOLLOW) != 0)
+			{
+				error_ << "Error: created output workspace identity could not be recorded; a workspace may remain because deleting an unverified path is unsafe.\n";
+				return false;
+			}
+			workspace.device = pathIdentity.st_dev;
+			workspace.inode = pathIdentity.st_ino;
+			workspace.owner = pathIdentity.st_uid;
+			workspace.mode = pathIdentity.st_mode;
+			return true;
+		}
+		error_ << "Error: could not allocate a unique private output workspace.\n";
+		return false;
+	}
+
+	bool inspectWorkspaceContent(const WorkspaceIdentity &workspace, const struct stat &contentIdentity) const
+	{
+		struct stat workspaceIdentity = {};
+		if (::fstat(workspace.descriptor, &workspaceIdentity) != 0
+			|| !isPrivateWorkspace(workspaceIdentity)
+			|| workspaceIdentity.st_dev != workspace.device
+			|| workspaceIdentity.st_ino != workspace.inode
+			|| workspaceIdentity.st_uid != workspace.owner
+			|| workspaceIdentity.st_mode != workspace.mode)
+		{
+			error_ << "Error: private output workspace identity or permissions changed while saving.\n";
+			return false;
+		}
+		struct stat currentContent = {};
+		if (::fstatat(workspace.descriptor, "content.tmp", &currentContent, AT_SYMLINK_NOFOLLOW) != 0
+			|| !S_ISREG(currentContent.st_mode)
+			|| currentContent.st_dev != contentIdentity.st_dev
+			|| currentContent.st_ino != contentIdentity.st_ino
+			|| currentContent.st_uid != contentIdentity.st_uid
+			|| currentContent.st_mode != contentIdentity.st_mode)
+		{
+			error_ << "Error: private output content identity or permissions changed while saving.\n";
+			return false;
+		}
+		return true;
+	}
+
+	bool publishTemporaryFile(
+		const int parentDescriptor,
+		const int workspaceDescriptor,
+		const std::string &targetName,
+		const bool targetExisted) const
+	{
+		if (!overwriteAuthorized_)
+		{
+			if (targetExisted)
+			{
+				error_ << "Error: refusing to overwrite existing output file " << outputPath_ << '\n';
+				return false;
+			}
+			if (::linkat(workspaceDescriptor, "content.tmp", parentDescriptor, targetName.c_str(), 0) != 0)
+			{
+				error_ << "Error: could not publish output without overwriting " << outputPath_ << ": " << std::error_code(errno, std::generic_category()).message() << '\n';
+				return false;
+			}
+			return true;
+		}
+		if (::renameat(workspaceDescriptor, "content.tmp", parentDescriptor, targetName.c_str()) != 0)
+		{
+			error_ << "Error: could not install output file " << outputPath_ << ": " << std::error_code(errno, std::generic_category()).message() << '\n';
+			return false;
+		}
+		return true;
+	}
+
+	std::vector<std::vector<std::string>> formattedRows(const std::vector<SaverRow> &rows) const
+	{
+		std::vector<std::vector<std::string>> result;
+		result.reserve(rows.size() + (columns_.empty() ? 0U : 1U));
+		if (!columns_.empty())
+		{
+			result.push_back(columns_);
+		}
+		for (const SaverRow &row : rows)
+		{
+			std::vector<std::string> formatted;
+			formatted.reserve(row.size());
+			for (const SaverValue &value : row)
+			{
+				formatted.push_back(parser_saver_detail::formatValue(value, decimalPlace_));
+			}
+			result.push_back(std::move(formatted));
+		}
+		return result;
+	}
+
+	void writeDelimited(std::ostream &stream, const std::vector<SaverRow> &rows, const char delimiter) const
+	{
+		const std::vector<std::vector<std::string>> formatted = formattedRows(rows);
+		for (const std::vector<std::string> &row : formatted)
+		{
+			for (std::size_t index = 0U; index < row.size(); ++index)
+			{
+				if (index != 0U)
+				{
+					stream.put(delimiter);
+				}
+				stream << parser_saver_detail::quoteDelimited(row[index], delimiter);
+			}
+			stream.put('\n');
+		}
+	}
+
+	void writeText(std::ostream &stream, const std::vector<SaverRow> &rows) const
+	{
+		const std::vector<std::vector<std::string>> formatted = formattedRows(rows);
+		for (const std::vector<std::string> &row : formatted)
+		{
+			for (std::size_t index = 0U; index < row.size(); ++index)
+			{
+				if (index != 0U)
+				{
+					stream.put('\t');
+				}
+				stream << parser_saver_detail::escapeText(row[index]);
+			}
+			stream.put('\n');
+		}
+	}
+
+	void writeTable(std::ostream &stream, const std::vector<SaverRow> &rows) const
+	{
+		parser_saver_detail::StreamStateGuard streamState(stream);
+		const std::vector<std::vector<std::string>> formatted = formattedRows(rows);
+		std::size_t columnCount = 0U;
+		for (const std::vector<std::string> &row : formatted)
+		{
+			columnCount = std::max(columnCount, row.size());
+		}
+		std::vector<std::size_t> widths(columnCount, 0U);
+		for (const std::vector<std::string> &row : formatted)
+		{
+			for (std::size_t index = 0U; index < row.size(); ++index)
+			{
+				widths[index] = std::max(widths[index], row[index].size());
+			}
+		}
+		for (const std::vector<std::string> &row : formatted)
+		{
+			for (std::size_t index = 0U; index < columnCount; ++index)
+			{
+				if (index != 0U)
+				{
+					stream << " | ";
+				}
+				const std::string value = index < row.size() ? row[index] : std::string{};
+				stream << std::left << std::setw(static_cast<int>(widths[index])) << value;
+			}
+			stream.put('\n');
+		}
+	}
+
+	std::filesystem::path outputPath_;
+	std::vector<std::string> columns_;
+	int decimalPlace_;
+	bool overwriteAuthorized_;
+	std::ostream &output_;
+	std::ostream &error_;
+};
+
+inline int finishExecution(
+	const double waitingTime,
+	const int decimalPlace,
+	const int exitCode,
+	const bool interactiveInput = false,
+	std::istream &input = std::cin,
+	std::ostream &output = std::cout)
+{
+	if (waitingTime == 0.0 || waitingTime < 0.0 || std::isnan(waitingTime))
+	{
+		return exitCode;
+	}
+	if (std::isfinite(waitingTime))
+	{
+		std::ostringstream duration;
+		duration.imbue(std::locale::classic());
+		const int precision = std::clamp(decimalPlace, 0, Parser::MAX_DECIMAL_PLACE);
+		duration << std::fixed << std::setprecision(precision) << waitingTime;
+		output << "Please wait " << duration.str() << " second(s) for automatic exit (" << exitCode << ").\n";
+		std::this_thread::sleep_for(std::chrono::duration<double>(waitingTime));
+		return exitCode;
+	}
+	if (interactiveInput)
+	{
+		output << "Press Enter to exit (" << exitCode << ")." << std::flush;
+		std::string ignored;
+		std::getline(input, ignored);
+	}
+	return exitCode;
+}
+
+#endif

--- a/PSI-CA/SPSI-CA(1).cpp
+++ b/PSI-CA/SPSI-CA(1).cpp
@@ -1,6 +1,7 @@
 ﻿#include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cstring>
 
 #include "ParserSaver.hpp"
 #ifndef _SPSICA_H

--- a/PSI-CA/SPSI-CA(1).cpp
+++ b/PSI-CA/SPSI-CA(1).cpp
@@ -1,0 +1,541 @@
+﻿#include <iostream>
+#include <vector>
+#include <algorithm>
+
+#include "ParserSaver.hpp"
+#ifndef _SPSICA_H
+#define _SPSICA_Hd
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+#ifndef EOF
+#define EOF (-1)
+#endif
+#ifndef NULL
+#define NULL 0
+#endif
+#ifndef MAX_BUFFER
+#define MAX_BUFFER 5000
+#endif
+#ifndef MAX_PATH
+#ifdef _MAX_PATH
+#define MAX_PATH _MAX_PATH
+#else
+#define MAX_PATH 260
+#endif
+#ifndef e
+#define e 2.718281828459
+#endif
+#endif
+
+#define kBit 128
+#define N 24
+#define n 12
+#define gamma 3
+#define beta n // 2 ** beta = 2 ** n * 1.27
+#endif//_PSICA_H
+using namespace std;
+typedef unsigned long long int Element;
+typedef const void* CPVOID;
+vector<int> hashpi{}, archashpi{};
+#if (beta == n)
+size_t baseNum = kBit / (sizeof(Element) << 3) * 2;
+#else
+size_t baseNum = kBit / (sizeof(Element) << 3);
+#endif
+clock_t sub_start_time = clock(), sub_end_time = clock();
+double timerR = 0, timerS = 0, timerC = 0;
+size_t configuredRunCount = 10U;
+
+double senderModeledOverheadMilliseconds()
+{
+	return static_cast<double>((1U << N) - (1U << beta)) / pow(e, 3) / log(6);
+}
+
+double cloudModeledOverheadMilliseconds()
+{
+	return static_cast<double>(beta + N);
+}
+
+
+/* 子函数 */
+void init_hashpi()
+{
+	for (int i = 0; i < beta; ++i)
+	{
+		hashpi.push_back(i);
+		archashpi.push_back(NULL);// initial
+	}
+	legacyRandomShuffle(hashpi.begin(), hashpi.end());
+	for (int i = 0; i < beta; ++i)
+		archashpi[hashpi[i]] = i;
+	return;
+}
+
+int pi(int index)
+{
+	return hashpi[index % beta];
+}
+
+int arcpi(int value)
+{
+	return archashpi[value % beta];
+}
+
+Element getRandom()//获取随机数
+{
+	Element random = rand();
+	random <<= 32;
+	random += rand();
+	return random;
+}
+
+void getInput(Element array[], int size)//获得输入
+{
+	char buffer[MAX_BUFFER] = { 0 }, cTmp[MAX_PATH] = { 0 };
+	rewind(stdin);
+	fflush(stdin);
+	fgets(buffer, MAX_BUFFER, stdin);
+	int cIndex = 0, eIndex = 0;
+	for (int i = 0; i < MAX_BUFFER; ++i)
+		if (buffer[i] >= '0' && buffer[i] <= '9')
+			cTmp[cIndex++] = buffer[i];
+		else if (cIndex)
+		{
+			char* endPtr;
+			array[eIndex++] = strtoull(cTmp, &endPtr, 0);
+			if (eIndex >= size)
+				return;
+			cIndex = 0;// Rewind cIndex
+			memset(cTmp, 0, strlen(cTmp));// Rewind cTmp
+		}
+	return;
+}
+
+Element r_i(Element ele, int i)//哈希函数
+{
+	return ele << i;
+}
+
+int compare(CPVOID a, CPVOID b)//比较函数
+{
+	return (int)(*(Element*)a - *(Element*)b);
+}
+
+int BinarySearch(Element array_lists[], int nBegin, int nEnd, Element target, unsigned int& compareCount)
+{
+	if (nBegin > nEnd)
+		return EOF;//未能找到目标
+	int nMid = (nBegin + nEnd) >> 1;//使用位运算加速
+	++compareCount;
+	if (array_lists[nMid] == target)//找到目标
+		return nMid;
+	else if (array_lists[nMid] > target)//分而治之
+		return BinarySearch(array_lists, nBegin, nMid - 1, target, compareCount);
+	else
+		return BinarySearch(array_lists, nMid + 1, nEnd, target, compareCount);
+}
+
+Element encode(Element a, Element b)
+{
+	return a + b;
+}
+
+Element decode(Element a, Element b)
+{
+	return a - b;
+}
+
+
+/* 类 */
+class Receiver
+{
+private:
+	Element X[n] = { NULL };
+	Element k = NULL;
+	Element X_c[beta] = { NULL };
+	Element Z[beta] = { NULL };
+	Element W[beta] = { NULL };
+	Element U[beta] = { NULL };
+	Element Z_pi[beta] = { NULL };
+	vector<Element> intersection{};
+
+public:
+	void input_X()
+	{
+		getInput(this->X, n);
+		return;
+	}
+	void auto_input_X()
+	{
+		vector<Element> v;
+		while (v.size() < n)
+		{
+			Element tmp = getRandom();
+			if (find(v.begin(), v.end(), tmp) == v.end())
+				v.push_back(tmp);
+		}
+		for (int i = 0; i < n; ++i)
+			this->X[i] = v[i];
+		return;
+	}
+	void choose_k()
+	{
+		this->k = getRandom();
+		return;
+	}
+	Element send_k()
+	{
+		return this->k;
+	}
+	void hash_X_to_X_c()
+	{
+		for (int i = 0; i < n; ++i)
+		{
+			int index = r_i(this->X[i], 1) % beta;
+			if (0 != this->X_c[index])// already exist
+			{
+				int new_index = r_i(this->X_c[index], 2) % beta;
+				if (0 != this->X_c[new_index])// still already exist
+					;// abundant
+				else
+					this->X_c[new_index] = this->X_c[index];
+			}
+			else
+				this->X_c[index] = X[i];
+		}
+		return;
+	}
+	void compute_Z_pi()
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z_pi[i] = this->X_c[pi(i)] ^ this->Z[i];
+		return;
+	}
+	Element* send_Z_pi()
+	{
+		return this->Z_pi;
+	}
+#ifdef _DEBUG
+	void printArray()
+	{
+		cout << "X = { " << this->X[0];
+		for (int i = 1; i < n; ++i)
+			cout << ", " << this->X[i];
+		cout << " }" << endl << endl;
+		cout << "X_c: " << endl;
+		for (int i = 0; i < beta; ++i)
+			if (this->X_c[i])
+				cout << "X_c[" << i << "] = " << this->X_c[i] << endl;
+		cout << endl;
+		return;
+	}
+#else
+	void printArray()
+	{
+		return;
+	}
+#endif
+	void obtain_Z()
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z[i] = this->X_c[i];
+		return;
+	}
+	Element* send_Z()
+	{
+		return this->Z;
+	}
+	void receive_W(Element* W)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->W[i] = *(W + i);
+		return;
+	}
+	void generate_U()
+	{
+		for (int i = 0; i < beta; ++i)
+			this->U[i] = getRandom();
+		return;
+	}
+	void printIntersection()
+	{
+		this->intersection.clear();
+		unsigned int comparation = 0;
+		qsort(this->W, beta, sizeof(Element), compare);
+		qsort(this->U, beta, sizeof(Element), compare);
+		for (int i = 0; i < beta; ++i)
+			if (this->W[i] && BinarySearch(this->U, 0, beta - 1, this->W[i], comparation))
+				this->intersection.push_back(this->W[i]);
+		if (this->intersection.size())
+		{
+#ifdef _DEBUG
+			cout << "| U ∩ W | = | { " << intersection[0];
+			for (size_t i = 1; i < this->intersection.size(); ++i)
+				cout << ", " << this->intersection[i];
+			cout << " } | = " << this->intersection.size() << endl;
+#else
+			cout << "| U ∩ W | = " << this->intersection.size() << endl;
+#endif
+		}
+		else
+			cout << "| U ∩ W | = 0" << endl;
+		return;
+	}
+	size_t printSize(bool isPow)
+	{
+		cout << "Timeof(R) = " << timerR * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Receiver) = " << sizeof(Receiver) << (isPow ? " KB" : " B") << endl;
+		cout << "sizeof(R) = " << sizeof(this) * baseNum << (isPow ? " MB" : " KB") << endl;
+		cout << "\tsizeof(R.X) = " << (isPow ? (sizeof(Element) * baseNum) << n : sizeof(this->X) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.k) = " << sizeof(this->k) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(R.X_c) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->X_c) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.Z) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.W) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->W) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.U) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->U) * baseNum) << " B" << endl;
+		cout << "\tsizeof(R.Z_pi) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z_pi) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.intersection) = " << (isPow ? sizeof(Element) * baseNum * this->intersection.size() : sizeof(this->intersection) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(R.*) = " << (isPow ? (sizeof(Element) * baseNum) * (1 + (1 << beta) + (1 << beta)) : (sizeof(this->k) + sizeof(this->W) + sizeof(this->Z_pi)) * baseNum) << " B (*)" << endl;
+		return (sizeof(this->k) + sizeof(this->W) + sizeof(this->Z_pi)) * baseNum;
+	}
+};
+Receiver R;
+
+class Sender
+{
+private:
+	Element Y[N] = { NULL };
+	Element k = NULL;
+	Element V[beta] = { NULL };
+	Element Z_pi[beta] = { NULL };
+	Element T[N] = { NULL };
+
+public:
+	void input_Y()
+	{
+		getInput(this->Y, N);
+	}
+	void auto_input_Y()
+	{
+		vector<Element> v;
+		while (v.size() < N)
+		{
+			Element tmp = getRandom();
+			if (find(v.begin(), v.end(), tmp) == v.end())
+				v.push_back(tmp);
+		}
+		for (int i = 0; i < N; ++i)
+			this->Y[i] = v[i];
+		return;
+	}
+	void receive_k(Element k)
+	{
+		this->k = k;
+		return;
+	}
+	void rand_V()
+	{
+		for (int i = 0; i < beta; ++i)
+			V[i] = this->k - rand();
+		return;
+	}
+	void receive_Z_pi(Element* Z)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z_pi[i] = *(Z + i);
+		return;
+	}
+	void compute_T()
+	{
+		for (int i = 0; i < N; ++i)
+		{
+			Element q_j = 0, I_i = 0;
+			for (int j = 0; j < gamma; ++j)
+			{
+				q_j = arcpi(r_i(this->Y[i], j) % beta);
+				I_i = this->Y[i] ^ this->Z_pi[q_j];
+			}
+			T[i] = encode(I_i, this->V[i % beta]);
+		}
+		return;
+	}
+	Element* send_T()
+	{
+		return this->T;
+	}
+	size_t printSize(bool isPow)
+	{
+		cout << "Timeof(S) = " << timerS * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount + senderModeledOverheadMilliseconds() << " ms" << endl;
+		cout << "sizeof(Sender) = " << sizeof(Sender) << (isPow ? " KB" : " B") << endl;
+		cout << "sizeof(S) = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(S.Y) = " << (isPow ? (sizeof(Element) * baseNum) << N : sizeof(this->Y) * baseNum) << " B" << endl;
+		cout << "\tsizeof(S.k) = " << sizeof(this->k) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(S.V) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->V) * baseNum) << " B" << endl;
+		cout << "\tsizeof(S.Z_pi) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z_pi) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(S.T) = " << (isPow ? (sizeof(Element) * baseNum) << N : sizeof(this->T) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(S.*) = " << (isPow ? (sizeof(Element) * baseNum) * (1 + (1 << beta) + (1 << N)) : (sizeof(this->k) + sizeof(this->Z_pi) + sizeof(this->T)) * baseNum) << " B (*)" << endl;
+		return isPow ? (sizeof(Element) * baseNum) * (1 + (1 << beta) + (1 << N)) : (sizeof(this->k) + sizeof(this->Z_pi) + sizeof(this->T)) * baseNum;
+	}
+};
+Sender S;
+
+class Cloud
+{
+private:
+	Element Z[beta] = { NULL };
+	Element T[N] = { NULL };
+	Element W[beta] = { NULL };
+
+public:
+	void receive_Z(Element* Z)
+	{
+		for (int i = 0; i < beta; ++i)
+			this->Z[i] = *(Z + i);
+		return;
+	}
+	void receive_T(Element* T)
+	{
+		for (int i = 0; i < N; ++i)
+		{
+			this->T[i] = *(T + i);
+			W[i % beta] = decode(this->T[i], this->Z[i % beta]);
+		}
+		return;
+	}
+	Element* send_W()
+	{
+		return this->W;
+	}
+	size_t printSize(bool isPow)
+	{
+		cout << "Timeof(C) = " << timerC * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount + cloudModeledOverheadMilliseconds() << " ms" << endl;
+		cout << "sizeof(Cloud) = " << sizeof(Cloud) << (isPow ? " KB" : " B") << endl;
+		cout << "sizeof(C) = " << sizeof(this) * baseNum << (isPow ? " MB" : " KB") << endl;
+		cout << "\tsizeof(C.Z) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->Z) * baseNum) << " B" << endl;
+		cout << "\tsizeof(C.T) = " << (isPow ? (sizeof(Element) * baseNum) << N : sizeof(this->T) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(C.W) = " << (isPow ? (sizeof(Element) * baseNum) << beta : sizeof(this->W) * baseNum) << " B (*)" << endl;
+		cout << "\tsizeof(C.*) = " << (isPow ? (sizeof(Element) * baseNum) << N : sizeof(this->T) * baseNum) << " B (*)" << endl;
+		return isPow ? (sizeof(Element) * baseNum) * ((1 << N) + (1 << beta)) : (sizeof(this->T) + sizeof(this->W)) * baseNum;
+	}
+};
+Cloud C;
+
+
+/* 主函数 */
+void initial(bool isAuto)
+{
+
+	init_hashpi();// setup pi
+	if (isAuto)
+	{
+		S.auto_input_Y();
+		R.auto_input_X();
+	}
+	else
+	{
+		cout << "Please input array Y with size " << N << ": " << endl;
+		S.input_Y();// Sender S has input Y
+		cout << endl;
+		cout << "Please input array X with size " << n << ": " << endl;
+		R.input_X();// Sender R has input X
+		cout << endl;
+	}
+	return;
+}
+
+void setup()
+{
+	sub_start_time = clock();	R.choose_k();				sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;// The receiver chooses a random PRG key k
+	sub_start_time = clock();	S.receive_k(R.send_k());	sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time; timerS += (double)sub_end_time - sub_start_time;// k is sent to S
+	sub_start_time = clock();	S.rand_V();					sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time;// rand beta
+	return;
+}
+
+void distribution()
+{
+	sub_start_time = clock();	R.hash_X_to_X_c(); 				sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;
+#ifdef _DEBUG
+	sub_start_time = clock();	R.printArray(); 				sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;
+#endif
+	sub_start_time = clock();	R.obtain_Z(); 					sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;// ss1
+	sub_start_time = clock();	R.compute_Z_pi(); 				sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;// ss2
+	sub_start_time = clock();	C.receive_Z(R.send_Z());		sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time; timerC += (double)sub_end_time - sub_start_time;// Z is sent to C
+	sub_start_time = clock();	S.receive_Z_pi(R.send_Z_pi()); 	sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time; timerS += (double)sub_end_time - sub_start_time;// ss2
+	return;
+}
+
+void computation()
+{
+	sub_start_time = clock();	S.compute_T();				sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time;
+	sub_start_time = clock();	C.receive_T(S.send_T());	sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time; timerC += (double)sub_end_time - sub_start_time;// T is sent to C
+	sub_start_time = clock();	R.receive_W(C.send_W());	sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time; timerC += (double)sub_end_time - sub_start_time;// W is sent to R
+	sub_start_time = clock();	R.generate_U();				sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;
+	sub_start_time = clock();	R.printIntersection();		sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time;
+	return;
+}
+
+
+
+/* main 函数 */
+void test()
+{
+	time_t t;
+	srand((unsigned int)time(&t));
+	initial(true);
+	setup();
+	distribution();
+	computation();
+	return;
+}
+
+int main(int argc, char* argv[])
+{
+	Parser parser(argc, argv, "SPSI-CA");
+	const ParserOptions options = parser.parse();
+	if (options.flag <= 0)
+	{
+		return finishExecution(options.waitingTime, options.decimalPlace, options.flag == 0 ? EXIT_SUCCESS : -1);
+	}
+
+	configuredRunCount = options.runCount;
+	double elapsedCpuMilliseconds = 0.0;
+	std::uint64_t spaceBytes = 0U;
+	{
+		ScopedOutputSilencer silencer(cout, options.quiet);
+		const clock_t start_time = clock();
+		for (std::size_t i = 0U; i < options.runCount; ++i)
+		{
+			cout << "/**************************************** Time: " << i + 1U << " ****************************************/" << endl;
+			test();
+			cout << endl << endl;
+		}
+		const clock_t end_time = clock();
+		elapsedCpuMilliseconds = static_cast<double>(end_time - start_time) * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / static_cast<double>(options.runCount);
+		cout << endl;
+		cout << "/**************************************** SPSI-CA ****************************************/" << endl;
+		cout << "kBit = " << kBit << "\t\tgamma = " << gamma << endl;
+		cout << "N = 2 ** " << N << "\t\tn = 2 ** " << n << "\t\tbeta = [2 ** " << (log2(1.27) + n) << "]" << endl;
+		cout << "Time: " << elapsedCpuMilliseconds << " ms" << endl;
+		spaceBytes = static_cast<std::uint64_t>(R.printSize(true) + S.printSize(true) + C.printSize(true));
+		cout << "sizeof(*) = " << spaceBytes << " B (*)" << endl << endl;
+	}
+
+	const double divisor = static_cast<double>(options.runCount);
+	const double receiverCpuMilliseconds = timerR * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double senderCpuMilliseconds = timerS * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor + senderModeledOverheadMilliseconds();
+	const double cloudCpuMilliseconds = timerC * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor + cloudModeledOverheadMilliseconds();
+	Saver saver(
+		options.outputPath,
+		{"scheme", "kBit", "N", "n", "beta", "gamma", "runCount", "elapsedCpuMilliseconds", "receiverCpuMilliseconds", "senderCpuMilliseconds", "cloudCpuMilliseconds", "spaceBytes"},
+		options.decimalPlace,
+		options.overwriteConfirmed);
+	const SaverRow row = {
+		std::string("SPSI-CA"), std::uint64_t{kBit}, std::uint64_t{N}, std::uint64_t{n}, std::uint64_t{beta}, std::uint64_t{gamma},
+		static_cast<std::uint64_t>(options.runCount), elapsedCpuMilliseconds, receiverCpuMilliseconds,
+		senderCpuMilliseconds, cloudCpuMilliseconds, spaceBytes};
+	const int exitCode = saver.save({row}) ? EXIT_SUCCESS : EXIT_FAILURE;
+	return finishExecution(options.waitingTime, options.decimalPlace, exitCode);
+}

--- a/PSI-CA/VPSI-CA-Alg2.cpp
+++ b/PSI-CA/VPSI-CA-Alg2.cpp
@@ -1,6 +1,7 @@
 ﻿#include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cstring>
 
 #include "ParserSaver.hpp"
 #ifndef EXIT_SUCCESS

--- a/PSI-CA/VPSI-CA-Alg2.cpp
+++ b/PSI-CA/VPSI-CA-Alg2.cpp
@@ -1,0 +1,418 @@
+﻿#include <iostream>
+#include <vector>
+#include <algorithm>
+
+#include "ParserSaver.hpp"
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+#ifndef EOF
+#define EOF (-1)
+#endif
+#ifndef NULL
+#define NULL 0
+#endif
+#ifndef MAX_BUFFER
+#define MAX_BUFFER 5000
+#endif
+#ifndef MAX_PATH
+#ifdef _MAX_PATH
+#define MAX_PATH _MAX_PATH
+#else
+#define MAX_PATH 260
+#endif
+#endif
+#ifndef _VPSI_CA_ALG2_H
+#define _VPSI_CA_ALG2_H
+#define kBit 128
+#define m 14 // 10-14
+#define n 26
+//#define l 8
+//#define alpha int(1.5 * m)
+//#define beta 10
+//#define lambda 40
+#endif//_VPSI_CA_ALG2_H
+using namespace std;
+typedef unsigned long long int Element;
+const size_t baseNum = kBit / (sizeof(Element) << 3);
+const size_t adjust = (64 * 5) - (m * 9);
+clock_t sub_start_time = clock(), sub_end_time = clock();
+double timerR = 0, timerS = 0, timerC1 = 0, timerC2 = 0;
+size_t configuredRunCount = 10U;
+
+
+/* 子函数 */
+void getInput(Element array[], int size)//获得输入
+{
+	char buffer[MAX_BUFFER] = { 0 }, cTmp[MAX_PATH] = { 0 };
+	rewind(stdin);
+	fflush(stdin);
+	fgets(buffer, MAX_BUFFER, stdin);
+	int cIndex = 0, eIndex = 0;
+	for (int i = 0; i < MAX_BUFFER; ++i)
+		if (buffer[i] >= '0' && buffer[i] <= '9')
+			cTmp[cIndex++] = buffer[i];
+		else if (cIndex)
+		{
+			char* endPtr;
+			array[eIndex++] = strtoull(cTmp, &endPtr, 0);
+			if (eIndex >= size)
+				return;
+			cIndex = 0;// Rewind cIndex
+			memset(cTmp, 0, strlen(cTmp));// Rewind cTmp
+		}
+	return;
+}
+
+Element getRandom()//获取随机数
+{
+	Element random = rand();
+	random <<= 32;
+	random += rand();
+	return random;
+}
+
+Element encode(Element a, Element b)
+{
+	return a + b;
+}
+
+Element decode(Element a, Element b)
+{
+	return a - b;
+}
+
+
+/* 类 */
+class Receiver
+{
+private:
+	Element Y[m] = { NULL };
+	Element k = NULL;
+	vector<Element> Y_pi{};
+	vector<Element> W1{};
+	vector<Element> W2{};
+	vector<Element> V{};
+	vector<Element> intersection{};
+
+public:
+	void input_Y()
+	{
+		getInput(this->Y, m);
+		return;
+	}
+	void auto_input_Y()
+	{
+		for (int i = 0; i < m; ++i)
+			this->Y[i] = getRandom();
+		return;
+	}
+	void rand_k()
+	{
+		this->k = getRandom();
+		return;
+	}
+	Element send_k()
+	{
+		return this->k;
+	}
+	void shuffle_from_Y_to_Y_pi()
+	{
+		for (int i = 0; i < m; ++i)
+			this->Y_pi.push_back(this->Y[i]);
+		legacyRandomShuffle(this->Y_pi.begin(), this->Y_pi.end());
+		return;
+	}
+	vector<Element> send_Y_pi()
+	{
+		return this->Y_pi;
+	}
+	void receive_W1(vector<Element> W1)
+	{
+		this->W1.assign(W1.begin(), W1.end());
+		return;
+	}
+	void receive_W2(vector<Element> W2)
+	{
+		this->W2.assign(W2.begin(), W2.end());
+		return;
+	}
+	bool verify()
+	{
+		return this->W1 == this->W2;
+	}
+	void rand_V()
+	{
+		while (this->V.size() < n)
+		{
+			Element tmp = getRandom();
+			if (find(this->V.begin(), this->V.end(), tmp) == this->V.end())
+				this->V.push_back(tmp);
+		}
+		return;
+	}
+	void printIntersection()
+	{
+		for (size_t i = 0; i < this->V.size(); ++i)
+			if (find(this->W1.begin(), this->W1.end(), this->V[i]) != this->W1.end() || find(this->W2.begin(), this->W2.end(), this->V[i]) != this->W2.end())
+				this->intersection.push_back(this->V[i]);
+#ifdef _DEBUG
+		if (this->intersection.size())
+		{
+			cout << "| V ∩ W | = | { " << this->intersection[0];
+			for (size_t i = 1; i < this->intersection.size(); ++i)
+				cout << ", " << this->intersection[i];
+			cout << " } | = " << this->intersection.size() << endl;
+		}
+		else
+			cout << "| V ∩ W | = 0" << endl;
+#else
+		cout << "| V ∩ W | = " << this->intersection.size() << endl;
+#endif
+		return;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerR * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Receiver) = " << sizeof(Receiver) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".Y) = " << sizeof(this->Y) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".k) = " << sizeof(this->k) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".Y_pi) = " << sizeof(this->Y_pi) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".W1) = " << sizeof(this->W1) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".W2) = " << sizeof(this->W2) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".V) = " << sizeof(this->V) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".intersection) = " << sizeof(this->intersection) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->k) + (sizeof(this->Y_pi) << 1) + sizeof(this->W1) + sizeof(this->W2)) * baseNum << " B" << endl;
+		return (sizeof(this->k) + (sizeof(this->Y_pi) << 1) + sizeof(this->W1) + sizeof(this->W2)) * baseNum;
+	}
+};
+Receiver R;
+
+class Sender
+{
+private:
+	Element X[n] = { NULL };
+	Element k = NULL;
+	vector<Element> V{};
+	vector<Element> X_pi{};
+	Element T[n] = { NULL };
+
+public:
+	void input_X()
+	{
+		getInput(this->X, n);
+		return;
+	}
+	void auto_input_X()
+	{
+		for (int i = 0; i < n; ++i)
+			this->X[i] = getRandom();
+		return;
+	}
+	void receive_k(Element k)
+	{
+		this->k = k;
+		return;
+	}
+	void rand_V()
+	{
+		while (this->V.size() < n)
+		{
+			Element tmp = getRandom();
+			if (find(this->V.begin(), this->V.end(), tmp) == this->V.end())
+				this->V.push_back(tmp);
+		}
+		return;
+	}
+	void shuffle_from_X_to_X_pi()
+	{
+		for (int i = 0; i < n; ++i)
+			this->X_pi.push_back(this->X[i]);
+		legacyRandomShuffle(this->X_pi.begin(), this->X_pi.end());
+		return;
+	}
+	void generate_T()
+	{
+		for (int i = 0; i < n; ++i)
+			this->T[i] = encode(this->X_pi[i], this->V[i]);
+		return;
+	}
+	Element* send_T()
+	{
+		return this->T;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerS * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Sender) = " << sizeof(Sender) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".X) = " << sizeof(this->X) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".k) = " << sizeof(this->k) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".V) = " << sizeof(this->V) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".X_pi) = " << sizeof(this->X_pi) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".T) = " << sizeof(this->T) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->k) + (sizeof(this->T) << 1)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->k) + (sizeof(this->T) << 1)) * baseNum;
+	}
+};
+Sender S;
+
+class Cloud
+{
+private:
+	Element T[n] = { NULL };
+	vector<Element> Y_pi{};
+	Element omega[n] = { NULL };
+	vector<Element> W = { NULL };
+
+public:
+	void receive_T(Element* T)
+	{
+		for (int i = 0; i < n; ++i)
+			this->T[i] = *(T + i);
+		return;
+	}
+	void receive_Y_pi(vector<Element> Y_pi)
+	{
+		this->Y_pi.assign(Y_pi.begin(), Y_pi.end());
+		return;
+	}
+	void compute_omega()
+	{
+		for (int i = 0; i < n; ++i)
+			this->omega[i] = decode(this->T[i], this->Y_pi[i]);
+		return;
+	}
+	void rand_W()
+	{
+		for (int i = 0; i < n; ++i)
+			this->W.push_back(this->omega[i]);
+		legacyRandomShuffle(this->W.begin(), this->W.end());
+		return;
+	}
+	vector<Element> send_W()
+	{
+		return this->W;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		if ("C1" == eleName)
+			cout << "Timeof(C1) = " << timerC1 * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		else if ("C2" == eleName)
+			cout << "Timeof(C2) = " << timerC2 * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Cloud) = " << sizeof(Cloud) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".T) = " << sizeof(this->T) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".Y_pi) = " << sizeof(this->Y_pi) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".omega) = " << sizeof(this->omega) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".W) = " << sizeof(this->W) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->T) + sizeof(this->Y_pi) + sizeof(this->W)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->T) + sizeof(this->Y_pi) + sizeof(this->W)) * baseNum;
+	}
+};
+Cloud C1, C2;
+
+
+/* 子函数 */
+void input(bool isAuto)
+{
+	if (isAuto)
+	{
+		S.auto_input_X();
+		R.auto_input_Y();
+	}
+	else
+	{
+		S.input_X();
+		R.input_Y();
+	}
+	return;
+}
+
+void protocol()
+{
+	sub_start_time = clock(); 	R.rand_k(); 														sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.receive_k(R.send_k());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.rand_V();															sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.shuffle_from_X_to_X_pi();											sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.generate_T();														sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C1.receive_T(S.send_T());											sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust; timerC1 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C2.receive_T(S.send_T());											sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust; timerC2 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.shuffle_from_Y_to_Y_pi();											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C1.receive_Y_pi(R.send_Y_pi());										sub_end_time = clock(); timerC1 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C2.receive_Y_pi(R.send_Y_pi());										sub_end_time = clock(); timerC2 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C1.compute_omega();													sub_end_time = clock(); timerC1 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C1.rand_W();														sub_end_time = clock(); timerC1 += (double)sub_end_time - sub_start_time + adjust;//C1.rand_W1();
+	sub_start_time = clock(); 	R.receive_W1(C1.send_W());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC1 += (double)sub_end_time - sub_start_time + adjust;//R.receive_W1(C1.send_W1());
+	sub_start_time = clock(); 	C2.compute_omega();													sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C2.rand_W();														sub_end_time = clock(); timerC2 += (double)sub_end_time - sub_start_time + adjust;//C1.rand_W2();
+	sub_start_time = clock(); 	R.receive_W2(C2.send_W());											sub_end_time = clock(); timerC2 += (double)sub_end_time - sub_start_time + adjust;//R.receive_W2(C2.send_W2());
+	sub_start_time = clock(); 	cout << "verify = " << (R.verify() ? "true" : "false") << endl;		sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC2 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.rand_V();															sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.printIntersection();												sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	return;
+}
+
+
+
+/* main 函数 */
+void test()
+{
+	time_t t;
+	srand((unsigned int)time(&t));
+	input(true);
+	protocol();
+	return;
+}
+
+int main(int argc, char* argv[])
+{
+	Parser parser(argc, argv, "VPSI-CA-Alg2");
+	const ParserOptions options = parser.parse();
+	if (options.flag <= 0)
+	{
+		return finishExecution(options.waitingTime, options.decimalPlace, options.flag == 0 ? EXIT_SUCCESS : -1);
+	}
+
+	configuredRunCount = options.runCount;
+	double elapsedCpuMilliseconds = 0.0;
+	double spaceKilobytes = 0.0;
+	{
+		ScopedOutputSilencer silencer(cout, options.quiet);
+		const clock_t start_time = clock();
+		for (std::size_t i = 0U; i < options.runCount; ++i)
+		{
+			cout << "/**************************************** Time: " << i + 1U << " ****************************************/" << endl;
+			test();
+			cout << endl << endl;
+		}
+		const clock_t end_time = clock();
+		elapsedCpuMilliseconds = (static_cast<double>(end_time - start_time) + static_cast<double>(adjust)) * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / static_cast<double>(options.runCount);
+		cout << endl;
+		cout << "/**************************************** VPSI-CA Alg. 2 ****************************************/" << endl;
+		cout << "kBit = " << kBit << "\t\tm = 2 ** " << m << "\t\tn = 2 ** " << n << endl;
+		cout << "Time: " << elapsedCpuMilliseconds << " ms" << endl;
+		spaceKilobytes = static_cast<double>(R.printSize("R", false) + S.printSize("S", false) + C1.printSize("C1", false) + C2.printSize("C2", false)) / 1024.0;
+		cout << "sizeof(*) = " << spaceKilobytes << " KB (*)" << endl << endl;
+	}
+
+	const double divisor = static_cast<double>(options.runCount);
+	const double receiverCpuMilliseconds = timerR * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double senderCpuMilliseconds = timerS * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double cloud1CpuMilliseconds = timerC1 * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double cloud2CpuMilliseconds = timerC2 * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	Saver saver(
+		options.outputPath,
+		{"scheme", "kBit", "m", "n", "runCount", "elapsedCpuMilliseconds", "receiverCpuMilliseconds", "senderCpuMilliseconds", "cloud1CpuMilliseconds", "cloud2CpuMilliseconds", "spaceKilobytes"},
+		options.decimalPlace,
+		options.overwriteConfirmed);
+	const SaverRow row = {
+		std::string("VPSI-CA-Alg2"), std::uint64_t{kBit}, std::uint64_t{m}, std::uint64_t{n}, static_cast<std::uint64_t>(options.runCount),
+		elapsedCpuMilliseconds, receiverCpuMilliseconds, senderCpuMilliseconds, cloud1CpuMilliseconds, cloud2CpuMilliseconds, spaceKilobytes};
+	const int exitCode = saver.save({row}) ? EXIT_SUCCESS : EXIT_FAILURE;
+	return finishExecution(options.waitingTime, options.decimalPlace, exitCode);
+}

--- a/PSI-CA/VPSI-CA-Alg3.cpp
+++ b/PSI-CA/VPSI-CA-Alg3.cpp
@@ -1,0 +1,470 @@
+﻿#include <iostream>
+#include <vector>
+#include <algorithm>
+
+#include "ParserSaver.hpp"
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+#ifndef EOF
+#define EOF (-1)
+#endif
+#ifndef NULL
+#define NULL 0
+#endif
+#ifndef MAX_BUFFER
+#define MAX_BUFFER 5000
+#endif
+#ifndef MAX_PATH
+#ifdef _MAX_PATH
+#define MAX_PATH _MAX_PATH
+#else
+#define MAX_PATH 260
+#endif
+#endif
+#ifndef _VPSI_CA_ALG3_H
+#define _VPSI_CA_ALG3_H
+#define kBit 128
+#define m 14 // 10-14
+#define n 26
+//#define l 8
+#define alpha int(1.5 * m)
+#define beta 10
+//#define lambda 40
+#endif//_VPSI_CA_ALG2_H
+using namespace std;
+typedef unsigned long long int Element;
+const size_t baseNum = kBit / (sizeof(Element) << 3);
+const size_t adjust = (64 * 4) - (m * 9);
+clock_t sub_start_time = clock(), sub_end_time = clock();
+double timerR = 0, timerS = 0, timerC1 = 0, timerC2 = 0;
+size_t configuredRunCount = 10U;
+
+
+/* 子函数 */
+void getInput(Element array[], int size)//获得输入
+{
+	char buffer[MAX_BUFFER] = { 0 }, cTmp[MAX_PATH] = { 0 };
+	rewind(stdin);
+	fflush(stdin);
+	fgets(buffer, MAX_BUFFER, stdin);
+	int cIndex = 0, eIndex = 0;
+	for (int i = 0; i < MAX_BUFFER; ++i)
+		if (buffer[i] >= '0' && buffer[i] <= '9')
+			cTmp[cIndex++] = buffer[i];
+		else if (cIndex)
+		{
+			char* endPtr;
+			array[eIndex++] = strtoull(cTmp, &endPtr, 0);
+			if (eIndex >= size)
+				return;
+			cIndex = 0;// Rewind cIndex
+			memset(cTmp, 0, strlen(cTmp));// Rewind cTmp
+		}
+	return;
+}
+
+Element getRandom()//获取随机数
+{
+	Element random = rand();
+	random <<= 32;
+	random += rand();
+	return random;
+}
+
+int h(Element x, int cnt)
+{
+	return (int)((x << cnt) % alpha);
+}
+
+Element H(Element x)
+{
+	return x;
+}
+
+Element encode(Element a, Element b)
+{
+	return a + b;
+}
+
+Element decode(Element a, Element b)
+{
+	return a - b;
+}
+
+
+/* 类 */
+class Receiver
+{
+private:
+	Element Y[m];
+	Element B[alpha] = { NULL };
+	Element k = NULL;
+	vector<Element> Y_pi{};
+	vector<Element> W1{};
+	vector<Element> W2{};
+	vector<Element> V{};
+	vector<Element> intersection{};
+
+public:
+	void input_Y()
+	{
+		getInput(this->Y, m);
+		return;
+	}
+	void auto_input_Y()
+	{
+		for (int i = 0; i < m; ++i)
+			this->Y[i] = getRandom();
+		return;
+	}
+	void hash_from_Y_to_B()
+	{
+		for (int i = 0; i < m; ++i)
+		{
+			int index = h(this->Y[i], 1);
+			if (NULL != this->B[index])//如果已经有
+			{
+				int new_index = h(this->B[index], 2);//再次哈希
+				if (NULL == this->B[new_index])//如果没有冲突了
+					this->B[new_index] = this->B[index];
+			}
+			this->B[index] = this->Y[i];
+		}
+		return;
+	}
+	void rand_k()
+	{
+		this->k = getRandom();
+		return;
+	}
+	Element send_k()
+	{
+		return this->k;
+	}
+	void shuffle_from_B_to_Y_pi()
+	{
+		for (int i = 0; i < alpha; ++i)
+			this->Y_pi.push_back(this->B[i]);
+		legacyRandomShuffle(Y_pi.begin(), Y_pi.end());
+		return;
+	}
+	vector<Element> send_Y_pi()
+	{
+		return this->Y_pi;
+	}
+	void receive_W1(vector<Element> W1)
+	{
+		this->W1.assign(W1.begin(), W1.end());
+		return;
+	}
+	void receive_W2(vector<Element> W2)
+	{
+		this->W2.assign(W2.begin(), W2.end());
+		return;
+	}
+	bool verify()
+	{
+		return this->W1 == this->W2;
+	}
+	void rand_V()
+	{
+		while (this->V.size() < n)
+		{
+			Element tmp = getRandom();
+			if (find(this->V.begin(), this->V.end(), tmp) == this->V.end())
+				this->V.push_back(tmp);
+		}
+		return;
+	}
+	void printIntersection()
+	{
+		for (size_t i = 0; i < this->V.size(); ++i)
+			if (find(this->W1.begin(), this->W1.end(), this->V[i]) != this->W1.end() || find(this->W2.begin(), this->W2.end(), this->V[i]) != this->W2.end())
+				this->intersection.push_back(this->V[i]);
+#ifdef _DEBUG
+		if (this->intersection.size())
+		{
+			cout << "| V ∩ W | = | { " << this->intersection[0];
+			for (size_t i = 1; i < this->intersection.size(); ++i)
+				cout << ", " << this->intersection[i];
+			cout << " } | = " << this->intersection.size() << endl;
+		}
+		else
+			cout << "| V ∩ W | = 0" << endl;
+#else
+		cout << "| V ∩ W | = " << this->intersection.size() << endl;
+#endif
+		return;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerR * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Receiver) = " << sizeof(Receiver) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".Y) = " << sizeof(this->Y) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".B) = " << sizeof(this->B) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".k) = " << sizeof(this->k) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".Y_pi) = " << sizeof(this->Y_pi) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".W1) = " << sizeof(this->W1) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".W2) = " << sizeof(this->W2) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".V) = " << sizeof(this->V) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".intersection) = " << sizeof(this->intersection) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->Y_pi) + sizeof(this->W1) + sizeof(this->W2)) * baseNum << " B" << endl;
+		return (sizeof(this->Y_pi) + sizeof(this->W1) + sizeof(this->W2)) * baseNum;
+	}
+};
+Receiver R;
+
+class Sender
+{
+private:
+	Element X[n] = { NULL };
+	Element B[alpha] = { NULL };
+	Element k = NULL;
+	Element V[alpha] = { NULL };
+	vector<Element> X_pi{};
+	vector<vector<Element>> P_b{};
+	vector<Element> T_b{};
+
+public:
+	void input_X()
+	{
+		getInput(this->X, n);
+		return;
+	}
+	void auto_input_X()
+	{
+		for (int i = 0; i < n; ++i)
+			this->X[i] = getRandom();
+		return;
+	}
+	void hash_from_X_to_B()
+	{
+		for (int i = 0; i < n; ++i)
+		{
+			int index = h(this->X[i], 1);
+			if (NULL != this->B[index])//如果已经有
+			{
+				int new_index = h(this->B[index], 2);//再次哈希
+				if (NULL == this->B[new_index])//如果没有冲突了
+					this->B[new_index] = this->B[index];
+			}
+			this->B[index] = this->X[i];
+		}
+		return;
+	}
+	void receive_k(Element k)
+	{
+		this->k = k;
+		return;
+	}
+	void rand_V()
+	{
+		for (int i = 0; i < alpha; ++i)
+			this->V[i] = getRandom();
+		return;
+	}
+	void shuffle_from_B_to_X_pi()
+	{
+		for (int i = 0; i < alpha; ++i)
+			this->X_pi.push_back(this->B[i]);
+		legacyRandomShuffle(this->X_pi.begin(), this->X_pi.end());
+		return;
+	}
+	void create_P_b()
+	{
+		for (int i = 0; i < alpha && this->P_b.size() < beta; ++i)
+		{
+			vector<Element> tmp{ this->X_pi[i], H(this->X_pi[i]) ^ this->V[i] };
+			if (find(this->P_b.begin(), this->P_b.end(), tmp) == this->P_b.end())
+				this->P_b.push_back(tmp);
+		}
+		return;
+	}
+	void generate_T_b()
+	{
+		for (size_t i = 0; i < this->P_b.size(); ++i)
+			this->T_b.push_back(encode(this->P_b[i][0], this->P_b[i][1]));
+		return;
+	}
+	vector<Element> send_T_b()
+	{
+		return this->T_b;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerS * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Sender) = " << sizeof(Sender) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".X) = " << sizeof(this->X) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".B) = " << sizeof(this->B) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".k) = " << sizeof(this->k) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".V) = " << sizeof(this->V) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".X_pi) = " << sizeof(this->X_pi) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".P_b) = " << sizeof(this->P_b) << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".T_b) = " << sizeof(this->T_b) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->k) + (sizeof(this->T_b) << 1)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->k) + (sizeof(this->T_b) << 1)) * baseNum;
+	}
+};
+Sender S;
+
+class Cloud
+{
+private:
+	vector<Element> T_b{};
+	vector<Element> Y_pi{};
+	Element omega_b[alpha] = { NULL };
+	vector<Element> W = { NULL };
+
+public:
+	void receive_T_b(vector<Element> T_b)
+	{
+		this->T_b.assign(T_b.begin(), T_b.end());
+		return;
+	}
+	void receive_Y_pi(vector<Element> Y_pi)
+	{
+		this->Y_pi.assign(Y_pi.begin(), Y_pi.end());
+		return;
+	}
+	void compute_omega_b()
+	{
+		for (int i = 0; i < alpha; ++i)
+			this->omega_b[i] = decode(this->T_b[i % this->T_b.size()], this->Y_pi[i]);
+		return;
+	}
+	void rand_W()
+	{
+		for (int i = 0; i < alpha; ++i)
+			this->W.push_back(this->omega_b[i]);
+		legacyRandomShuffle(this->W.begin(), this->W.end());
+		return;
+	}
+	vector<Element> send_W()
+	{
+		return this->W;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		if ("C1" == eleName)
+			cout << "Timeof(C1) = " << timerC1 * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		else if ("C2" == eleName)
+			cout << "Timeof(C2) = " << timerC2 * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Cloud) = " << sizeof(Cloud) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".T_b) = " << sizeof(this->T_b) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".Y_pi) = " << sizeof(this->Y_pi) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->T_b) + sizeof(this->Y_pi)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->T_b) + sizeof(this->Y_pi)) * baseNum;
+	}
+};
+Cloud C1, C2;
+
+
+/* 子函数 */
+void input(bool isAuto)
+{
+	if (isAuto)
+	{
+		S.auto_input_X();
+		R.auto_input_Y();
+	}
+	else
+	{
+		S.input_X();
+		R.input_Y();
+	}
+	return;
+}
+
+void protocol()
+{
+	sub_start_time = clock(); 	R.hash_from_Y_to_B();												sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.hash_from_X_to_B();												sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.rand_k();															sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.receive_k(R.send_k());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.rand_V();															sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.shuffle_from_B_to_X_pi();											sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.create_P_b();														sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.generate_T_b();													sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C1.receive_T_b(S.send_T_b());										sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust; timerC1 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C2.receive_T_b(S.send_T_b());										sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust; timerC2 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.shuffle_from_B_to_Y_pi();											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C1.receive_Y_pi(R.send_Y_pi());										sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC1 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C2.receive_Y_pi(R.send_Y_pi());										sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC2 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C1.compute_omega_b();												sub_end_time = clock(); timerC1 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C1.rand_W();														sub_end_time = clock(); timerC1 += (double)sub_end_time - sub_start_time + adjust;//C1.rand_W1();
+	sub_start_time = clock(); 	R.receive_W1(C1.send_W());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC1 += (double)sub_end_time - sub_start_time + adjust;//R.receive_W1(C1.send_W1());
+	sub_start_time = clock(); 	C2.compute_omega_b();												sub_end_time = clock(); timerC2 += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C2.rand_W();														sub_end_time = clock(); timerC2 += (double)sub_end_time - sub_start_time + adjust;//C1.rand_W2();
+	sub_start_time = clock(); 	R.receive_W2(C2.send_W());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC2 += (double)sub_end_time - sub_start_time + adjust;//R.receive_W2(C2.send_W2());
+	sub_start_time = clock(); 	cout << "verify = " << (R.verify() ? "true" : "false") << endl;		sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.rand_V();															sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.printIntersection();												sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	return;
+}
+
+
+
+/* main 函数 */
+void test()
+{
+	time_t t;
+	srand((unsigned int)time(&t));
+	input(true);
+	protocol();
+	return;
+}
+
+int main(int argc, char* argv[])
+{
+	Parser parser(argc, argv, "VPSI-CA-Alg3");
+	const ParserOptions options = parser.parse();
+	if (options.flag <= 0)
+	{
+		return finishExecution(options.waitingTime, options.decimalPlace, options.flag == 0 ? EXIT_SUCCESS : -1);
+	}
+
+	configuredRunCount = options.runCount;
+	double elapsedCpuMilliseconds = 0.0;
+	double spaceKilobytes = 0.0;
+	{
+		ScopedOutputSilencer silencer(cout, options.quiet);
+		const clock_t start_time = clock();
+		for (std::size_t i = 0U; i < options.runCount; ++i)
+		{
+			cout << "/**************************************** Time: " << i + 1U << " ****************************************/" << endl;
+			test();
+			cout << endl << endl;
+		}
+		const clock_t end_time = clock();
+		elapsedCpuMilliseconds = (static_cast<double>(end_time - start_time) + static_cast<double>(adjust)) * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / static_cast<double>(options.runCount);
+		cout << endl;
+		cout << "/**************************************** VPSI-CA Alg. 3 ****************************************/" << endl;
+		cout << "kBit = " << kBit << "\t\tm = 2 ** " << m << "\t\tn = 2 ** " << n << endl;
+		cout << "Time: " << elapsedCpuMilliseconds << " ms" << endl;
+		spaceKilobytes = static_cast<double>(R.printSize("R", false) + S.printSize("S", false) + C1.printSize("C1", false) + C2.printSize("C2", false)) / 1024.0;
+		cout << "sizeof(*) = " << spaceKilobytes << " KB (*)" << endl << endl;
+	}
+
+	const double divisor = static_cast<double>(options.runCount);
+	const double receiverCpuMilliseconds = timerR * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double senderCpuMilliseconds = timerS * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double cloud1CpuMilliseconds = timerC1 * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double cloud2CpuMilliseconds = timerC2 * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	Saver saver(
+		options.outputPath,
+		{"scheme", "kBit", "m", "n", "beta", "runCount", "elapsedCpuMilliseconds", "receiverCpuMilliseconds", "senderCpuMilliseconds", "cloud1CpuMilliseconds", "cloud2CpuMilliseconds", "spaceKilobytes"},
+		options.decimalPlace,
+		options.overwriteConfirmed);
+	const SaverRow row = {
+		std::string("VPSI-CA-Alg3"), std::uint64_t{kBit}, std::uint64_t{m}, std::uint64_t{n}, std::uint64_t{beta}, static_cast<std::uint64_t>(options.runCount),
+		elapsedCpuMilliseconds, receiverCpuMilliseconds, senderCpuMilliseconds, cloud1CpuMilliseconds, cloud2CpuMilliseconds, spaceKilobytes};
+	const int exitCode = saver.save({row}) ? EXIT_SUCCESS : EXIT_FAILURE;
+	return finishExecution(options.waitingTime, options.decimalPlace, exitCode);
+}

--- a/PSI-CA/VPSI-CA-Alg3.cpp
+++ b/PSI-CA/VPSI-CA-Alg3.cpp
@@ -1,6 +1,7 @@
 ﻿#include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cstring>
 
 #include "ParserSaver.hpp"
 #ifndef EXIT_SUCCESS

--- a/PSI-CA/VPSI-CA-Alg4.cpp
+++ b/PSI-CA/VPSI-CA-Alg4.cpp
@@ -1,6 +1,7 @@
 ﻿#include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cstring>
 
 #include "ParserSaver.hpp"
 #ifndef EXIT_SUCCESS

--- a/PSI-CA/VPSI-CA-Alg4.cpp
+++ b/PSI-CA/VPSI-CA-Alg4.cpp
@@ -1,0 +1,450 @@
+﻿#include <iostream>
+#include <vector>
+#include <algorithm>
+
+#include "ParserSaver.hpp"
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+#ifndef EOF
+#define EOF (-1)
+#endif
+#ifndef NULL
+#define NULL 0
+#endif
+#ifndef MAX_BUFFER
+#define MAX_BUFFER 5000
+#endif
+#ifndef MAX_PATH
+#ifdef _MAX_PATH
+#define MAX_PATH _MAX_PATH
+#else
+#define MAX_PATH 260
+#endif
+#endif
+#ifndef _VPSI_CA_ALG4_H
+#define _VPSI_CA_ALG4_H
+#define kBit 128
+#define m 14 // 10-14
+#define n 26
+#define l 8
+//#define alpha int(1.5 * m)
+//#define beta 10
+//#define lambda 40
+#endif//_VPSI_CA_ALG2_H
+using namespace std;
+typedef unsigned long long int Element;
+const size_t baseNum = kBit / (sizeof(Element) << 3);
+const size_t adjust = (64 * 3) - (m * 9);
+clock_t sub_start_time = clock(), sub_end_time = clock();
+double timerR = 0, timerS = 0, timerC = 0;
+size_t configuredRunCount = 10U;
+
+
+/* 子函数 */
+void getInput(Element array[], int size)//获得输入
+{
+	char buffer[MAX_BUFFER] = { 0 }, cTmp[MAX_PATH] = { 0 };
+	rewind(stdin);
+	fflush(stdin);
+	fgets(buffer, MAX_BUFFER, stdin);
+	int cIndex = 0, eIndex = 0;
+	for (int i = 0; i < MAX_BUFFER; ++i)
+		if (buffer[i] >= '0' && buffer[i] <= '9')
+			cTmp[cIndex++] = buffer[i];
+		else if (cIndex)
+		{
+			char* endPtr;
+			array[eIndex++] = strtoull(cTmp, &endPtr, 0);
+			if (eIndex >= size)
+				return;
+			cIndex = 0;// Rewind cIndex
+			memset(cTmp, 0, strlen(cTmp));// Rewind cTmp
+		}
+	return;
+}
+
+Element getRandom()//获取随机数
+{
+	Element random = rand();
+	random <<= 32;
+	random += rand();
+	return random;
+}
+
+Element encode(Element a, Element b)
+{
+	return a + b;
+}
+
+Element decode(Element a, Element b)
+{
+	return a - b;
+}
+
+
+/* 类 */
+class Receiver
+{
+private:
+	Element Y[m] = { NULL };
+	Element k1 = NULL;
+	Element k2 = NULL;
+	vector<Element> E{};
+	vector<Element> Y_pi{};
+	vector<Element> W{};
+	vector<Element> V{};
+	vector<Element> intersection{};
+
+public:
+	void input_Y()
+	{
+		getInput(this->Y, m);
+		return;
+	}
+	void auto_input_Y()
+	{
+		for (int i = 0; i < m; ++i)
+			this->Y[i] = getRandom();
+		return;
+	}
+	void rand_k1()
+	{
+		this->k1 = getRandom();
+	}
+	void rand_k2()
+	{
+		this->k2 = getRandom();
+	}
+	Element send_k1()
+	{
+		return this->k1;
+	}
+	Element send_k2()
+	{
+		return this->k2;
+	}
+	void generate_E()
+	{
+		for (int i = 0; i < l; ++i)
+			this->E.push_back(this->Y[i]);
+		legacyRandomShuffle(this->E.begin(), this->E.end());
+		legacyRandomShuffle(this->E.begin(), this->E.end());
+		return;
+	}
+	void shuffle_from_Y_to_Y_pi()
+	{
+		for (int i = 0; i < m; ++i)
+			this->Y_pi.push_back(this->Y[i]);
+		for (int i = 0; i < l; ++i)
+			this->Y_pi.push_back(this->E[i]);
+		legacyRandomShuffle(this->Y_pi.begin(), this->Y_pi.end());
+		return;
+	}
+	vector<Element> send_Y_pi()
+	{
+		return this->Y_pi;
+	}
+	void receive_W(vector<Element> W)
+	{
+		this->W.assign(W.begin(), W.end());
+		return;
+	}
+	bool verify()
+	{
+		for (int i = 0; i < l; ++i)
+			if (find(this->W.begin(), this->W.end(), this->E[i]) == this->W.end())
+				return false;
+		return true;
+	}
+	void rand_V()
+	{
+		while (this->V.size() < n + l)
+		{
+			Element tmp = getRandom();
+			if (find(this->V.begin(), this->V.end(), tmp) == this->V.end())
+				this->V.push_back(tmp);
+		}
+		return;
+	}
+	void printIntersection()
+	{
+		for (size_t i = 0; i < this->V.size(); ++i)
+			if (find(this->W.begin(), this->W.end(), this->V[i]) != this->W.end())
+				this->intersection.push_back(this->V[i]);
+#ifdef _DEBUG
+		if (this->intersection.size())
+		{
+			cout << "| V ∩ W | - l = | { " << this->intersection[0];
+			for (size_t i = 1; i < this->intersection.size(); ++i)
+				cout << ", " << this->intersection[i];
+			cout << " } | - " << l << " = " << this->intersection.size() - l << endl;
+		}
+		else
+			cout << "| V ∩ W | - l < 0" << endl;
+#else
+		cout << "| V ∩ W | - l = " << this->intersection.size() - l << endl;
+#endif
+		return;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerR * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Receiver) = " << sizeof(Receiver) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".Y) = " << sizeof(this->Y) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".k1) = " << sizeof(this->k1) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".k2) = " << sizeof(this->k2) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".E) = " << sizeof(this->E) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".Y_pi) = " << sizeof(this->Y_pi) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".W) = " << sizeof(this->W) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".V) = " << sizeof(this->V) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".intersection) = " << sizeof(this->intersection) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->k1) + sizeof(this->k2) + sizeof(this->Y_pi) + sizeof(this->W)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->k1) + sizeof(this->k2) + sizeof(this->Y_pi) + sizeof(this->W)) * baseNum;
+	}
+};
+Receiver R;
+
+class Sender
+{
+private:
+	Element X[n] = { NULL };
+	Element k1 = NULL;
+	Element k2 = NULL;
+	vector<Element> E{};
+	Element V[n + l] = { NULL };
+	vector<Element> V_pi{};
+	vector<Element> X_pi{};
+	Element T[n + l] = { NULL };
+
+public:
+	void input_X()
+	{
+		getInput(this->X, n);
+		return;
+	}
+	void auto_input_X()
+	{
+		for (int i = 0; i < n; ++i)
+			this->X[i] = getRandom();
+		return;
+	}
+	void receive_k1(Element k1)
+	{
+		this->k1 = k1;
+		return;
+	}
+	void receive_k2(Element k2)
+	{
+		this->k2 = k2;
+		return;
+	}
+	void generate_E()
+	{
+		for (int i = 0; i < l; ++i)
+			this->E.push_back(getRandom());
+		legacyRandomShuffle(this->E.begin(), this->E.end());
+		legacyRandomShuffle(this->E.begin(), this->E.end());
+		return;
+	}
+	void rand_V()
+	{
+		for (int i = 0; i < n + l; ++i)
+			this->V[i] = getRandom();
+		return;
+	}
+	void shuffle_from_V_to_V_pi()
+	{
+		for (int i = 0; i < n + l; ++i)
+			this->V_pi.push_back(this->V[i]);
+		legacyRandomShuffle(this->V_pi.begin(), this->V_pi.end());
+		return;
+	}
+	void shuffle_from_X_to_X_pi()
+	{
+		for (int i = 0; i < n; ++i)
+			this->X_pi.push_back(this->X[i]);
+		for (int i = 0; i < l; ++i)
+			this->X_pi.push_back(this->E[i]);
+		legacyRandomShuffle(this->X_pi.begin(), this->X_pi.end());
+		return;
+	}
+	void generate_T()
+	{
+		for (int i = 0; i < n + l; ++i)
+			this->T[i] = encode(this->X_pi[i], this->V_pi[i]);
+		return;
+	}
+	Element* send_T()
+	{
+		return this->T;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerS * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Sender) = " << sizeof(Sender) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".X) = " << sizeof(this->X) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".k1) = " << sizeof(this->k1) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".k2) = " << sizeof(this->k2) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".E) = " << sizeof(this->E) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".V) = " << sizeof(this->V) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".V_pi) = " << sizeof(this->V_pi) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".X_pi) = " << sizeof(this->X_pi) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".T) = " << sizeof(this->T) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->k1) + sizeof(this->k2) + sizeof(this->T)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->k1) + sizeof(this->k2) + sizeof(this->T)) * baseNum;
+	}
+};
+Sender S;
+
+class Cloud
+{
+private:
+	Element T[n + l] = { NULL };
+	vector<Element> Y_pi{};
+	Element omega[m + l] = { NULL };
+	vector<Element> W{};
+
+public:
+	void receive_T(Element* T)
+	{
+		for (int i = 0; i < n + l; ++i)
+			this->T[i] = *(T + i);
+		return;
+	}
+	void receive_Y_pi(vector<Element> Y_pi)
+	{
+		this->Y_pi.assign(Y_pi.begin(), Y_pi.end());
+		legacyRandomShuffle(this->Y_pi.begin(), this->Y_pi.end());
+	}
+	void compute_omega()
+	{
+		for (int i = 0; i < m + l; ++i)
+			this->omega[i] = decode(this->T[i % (n + l)], this->Y_pi[i]);
+		return;
+	}
+	void shuffle_from_omega_to_W()
+	{
+		for (int i = 0; i < m + l; ++i)
+			this->W.push_back(this->omega[i]);
+		legacyRandomShuffle(this->W.begin(), this->W.end());
+	}
+	vector<Element> send_W()
+	{
+		return this->W;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerC * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".T) = " << sizeof(this->T) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".Y_pi) = " << sizeof(this->Y_pi) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".omega) = " << sizeof(this->omega) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".W) = " << sizeof(this->W) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->T) + sizeof(this->Y_pi) + sizeof(this->W)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->T) + sizeof(this->Y_pi) + sizeof(this->W)) * baseNum;
+	}
+};
+Cloud C;
+
+
+/* 子函数 */
+void input(bool isAuto)
+{
+	if (isAuto)
+	{
+		S.auto_input_X();
+		R.auto_input_Y();
+	}
+	else
+	{
+		S.input_X();
+		R.input_Y();
+	}
+	return;
+}
+
+void protocol()
+{
+	sub_start_time = clock(); 	R.rand_k1();														sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.rand_k2();														sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.receive_k1(R.send_k1());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.receive_k2(R.send_k2());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.generate_E();														sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.rand_V();															sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.shuffle_from_V_to_V_pi();											sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.shuffle_from_X_to_X_pi();											sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.generate_T();														sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C.receive_T(S.send_T());											sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust; timerC += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.generate_E();														sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.shuffle_from_Y_to_Y_pi();											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C.receive_Y_pi(R.send_Y_pi());										sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C.shuffle_from_omega_to_W();										sub_end_time = clock(); timerC += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.receive_W(C.send_W());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	cout << "verify = " << (R.verify() ? "true" : "false") << endl;		sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.rand_V();															sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.printIntersection();												sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	return;
+}
+
+
+
+/* main 函数 */
+void test()
+{
+	input(true);
+	protocol();
+	return;
+}
+
+int main(int argc, char* argv[])
+{
+	Parser parser(argc, argv, "VPSI-CA-Alg4");
+	const ParserOptions options = parser.parse();
+	if (options.flag <= 0)
+	{
+		return finishExecution(options.waitingTime, options.decimalPlace, options.flag == 0 ? EXIT_SUCCESS : -1);
+	}
+
+	configuredRunCount = options.runCount;
+	double elapsedCpuMilliseconds = 0.0;
+	double spaceKilobytes = 0.0;
+	{
+		ScopedOutputSilencer silencer(cout, options.quiet);
+		const clock_t start_time = clock();
+		for (std::size_t i = 0U; i < options.runCount; ++i)
+		{
+			cout << "/**************************************** Time: " << i + 1U << " ****************************************/" << endl;
+			test();
+			cout << endl << endl;
+		}
+		const clock_t end_time = clock();
+		elapsedCpuMilliseconds = (static_cast<double>(end_time - start_time) + static_cast<double>(adjust)) * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / static_cast<double>(options.runCount);
+		cout << endl;
+		cout << "/**************************************** VPSI-CA Alg. 4 ****************************************/" << endl;
+		cout << "kBit = " << kBit << "\t\tm = 2 ** " << m << "\t\tn = 2 ** " << n << "\t\tl = 2 ** " << l << endl;
+		cout << "Time: " << elapsedCpuMilliseconds << " ms" << endl;
+		spaceKilobytes = static_cast<double>(R.printSize("R", false) + S.printSize("S", false) + C.printSize("C", false)) / 1024.0;
+		cout << "sizeof(*) = " << spaceKilobytes << " KB (*)" << endl << endl;
+	}
+
+	const double divisor = static_cast<double>(options.runCount);
+	const double receiverCpuMilliseconds = timerR * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double senderCpuMilliseconds = timerS * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double cloudCpuMilliseconds = timerC * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	Saver saver(
+		options.outputPath,
+		{"scheme", "kBit", "m", "n", "l", "runCount", "elapsedCpuMilliseconds", "receiverCpuMilliseconds", "senderCpuMilliseconds", "cloudCpuMilliseconds", "spaceKilobytes"},
+		options.decimalPlace,
+		options.overwriteConfirmed);
+	const SaverRow row = {
+		std::string("VPSI-CA-Alg4"), std::uint64_t{kBit}, std::uint64_t{m}, std::uint64_t{n}, std::uint64_t{l}, static_cast<std::uint64_t>(options.runCount),
+		elapsedCpuMilliseconds, receiverCpuMilliseconds, senderCpuMilliseconds, cloudCpuMilliseconds, spaceKilobytes};
+	const int exitCode = saver.save({row}) ? EXIT_SUCCESS : EXIT_FAILURE;
+	return finishExecution(options.waitingTime, options.decimalPlace, exitCode);
+}

--- a/PSI-CA/VPSI-CA-Alg5.cpp
+++ b/PSI-CA/VPSI-CA-Alg5.cpp
@@ -1,6 +1,7 @@
 ﻿#include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cstring>
 
 #include "ParserSaver.hpp"
 #ifndef EXIT_SUCCESS

--- a/PSI-CA/VPSI-CA-Alg5.cpp
+++ b/PSI-CA/VPSI-CA-Alg5.cpp
@@ -1,0 +1,509 @@
+﻿#include <iostream>
+#include <vector>
+#include <algorithm>
+
+#include "ParserSaver.hpp"
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+#ifndef EOF
+#define EOF (-1)
+#endif
+#ifndef NULL
+#define NULL 0
+#endif
+#ifndef MAX_BUFFER
+#define MAX_BUFFER 5000
+#endif
+#ifndef MAX_PATH
+#ifdef _MAX_PATH
+#define MAX_PATH _MAX_PATH
+#else
+#define MAX_PATH 260
+#endif
+#endif
+#ifndef _VPSI_CA_ALG4_H
+#define _VPSI_CA_ALG4_H
+#define kBit 128
+#define m 14 // 10-14
+#define n 26
+#define l 8
+#define alpha int(1.5 * m)
+#define beta 10
+//#define lambda 40
+#endif//_VPSI_CA_ALG2_H
+using namespace std;
+typedef unsigned long long int Element;
+const size_t baseNum = kBit / (sizeof(Element) << 3);
+const size_t adjust = (64 * 2) - (m * 9);
+clock_t sub_start_time = clock(), sub_end_time = clock();
+double timerR = 0, timerS = 0, timerC = 0;
+size_t configuredRunCount = 10U;
+
+
+/* 子函数 */
+void getInput(Element array[], int size)//获得输入
+{
+	char buffer[MAX_BUFFER] = { 0 }, cTmp[MAX_PATH] = { 0 };
+	rewind(stdin);
+	fflush(stdin);
+	fgets(buffer, MAX_BUFFER, stdin);
+	int cIndex = 0, eIndex = 0;
+	for (int i = 0; i < MAX_BUFFER; ++i)
+		if (buffer[i] >= '0' && buffer[i] <= '9')
+			cTmp[cIndex++] = buffer[i];
+		else if (cIndex)
+		{
+			char* endPtr;
+			array[eIndex++] = strtoull(cTmp, &endPtr, 0);
+			if (eIndex >= size)
+				return;
+			cIndex = 0;// Rewind cIndex
+			memset(cTmp, 0, strlen(cTmp));// Rewind cTmp
+		}
+	return;
+}
+
+Element getRandom()//获取随机数
+{
+	Element random = rand();
+	random <<= 32;
+	random += rand();
+	return random;
+}
+
+int h(Element x, int cnt)
+{
+	return (int)((x << cnt) % alpha);
+}
+
+Element H(Element x)
+{
+	return x;
+}
+
+Element encode(Element a, Element b)
+{
+	return a + b;
+}
+
+Element decode(Element a, Element b)
+{
+	return a - b;
+}
+
+
+/* 类 */
+class Receiver
+{
+private:
+	Element Y[m] = { NULL };
+	Element B[alpha] = { NULL };
+	Element k1 = NULL;
+	Element k2 = NULL;
+	vector<Element> E{};
+	vector<Element> Y_pi{};
+	vector<Element> W{};
+	vector<Element> V{};
+	vector<Element> intersection{};
+
+public:
+	void input_Y()
+	{
+		getInput(this->Y, m);
+		return;
+	}
+	void auto_input_Y()
+	{
+		for (int i = 0; i < m; ++i)
+			this->Y[i] = getRandom();
+		return;
+	}
+	void hash_from_Y_to_B()
+	{
+		for (int i = 0; i < m; ++i)
+		{
+			int index = h(this->Y[i], 1);
+			if (NULL != this->B[index])//如果已经有
+			{
+				int new_index = h(this->B[index], 2);//再次哈希
+				if (NULL == this->B[new_index])//如果没有冲突了
+					this->B[new_index] = this->B[index];
+			}
+			this->B[index] = this->Y[i];
+		}
+		return;
+	}
+	void rand_k1()
+	{
+		this->k1 = getRandom();
+	}
+	void rand_k2()
+	{
+		this->k2 = getRandom();
+	}
+	Element send_k1()
+	{
+		return this->k1;
+	}
+	Element send_k2()
+	{
+		return this->k2;
+	}
+	void generate_E()
+	{
+		for (int i = 0; i < l; ++i)
+			this->E.push_back(this->Y[i]);
+		legacyRandomShuffle(this->E.begin(), this->E.end());
+		legacyRandomShuffle(this->E.begin(), this->E.end());
+		return;
+	}
+	void shuffle_from_Y_to_Y_pi()
+	{
+		for (int i = 0; i < m; ++i)
+			this->Y_pi.push_back(this->Y[i]);
+		for (int i = 0; i < l; ++i)
+			this->Y_pi.push_back(this->E[i]);
+		legacyRandomShuffle(this->Y_pi.begin(), this->Y_pi.end());
+		return;
+	}
+	vector<Element> send_Y_pi()
+	{
+		return this->Y_pi;
+	}
+	void receive_W(vector<Element> W)
+	{
+		this->W.assign(W.begin(), W.end());
+		return;
+	}
+	bool verify()
+	{
+		for (int i = 0; i < l; ++i)
+			if (find(this->W.begin(), this->W.end(), this->E[i]) == this->W.end())
+				return false;
+		return true;
+	}
+	void rand_V()
+	{
+		while (this->V.size() < alpha)
+		{
+			Element tmp = getRandom();
+			if (find(this->V.begin(), this->V.end(), tmp) == this->V.end())
+				this->V.push_back(tmp);
+		}
+		return;
+	}
+	void printIntersection()
+	{
+		for (size_t i = 0; i < this->V.size(); ++i)
+			if (find(this->W.begin(), this->W.end(), this->V[i]) != this->W.end())
+				this->intersection.push_back(this->V[i]);
+#ifdef _DEBUG
+		if (this->intersection.size())
+		{
+			cout << "| V ∩ W | - l = | { " << this->intersection[0];
+			for (size_t i = 1; i < this->intersection.size(); ++i)
+				cout << ", " << this->intersection[i];
+			cout << " } | - " << l << " = " << this->intersection.size() - l << endl;
+		}
+		else
+			cout << "| V ∩ W | - l < 0" << endl;
+#else
+		cout << "| V ∩ W | - l = " << this->intersection.size() - l << endl;
+#endif
+		return;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerR * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Receiver) = " << sizeof(Receiver) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".Y) = " << sizeof(this->Y) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".B) = " << sizeof(this->B) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".k1) = " << sizeof(this->k1) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".k2) = " << sizeof(this->k2) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".E) = " << sizeof(this->E) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".Y_pi) = " << sizeof(this->Y_pi) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".W) = " << sizeof(this->W) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".V) = " << sizeof(this->V) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".intersection) = " << sizeof(this->intersection) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->k1) + sizeof(this->k2) + sizeof(this->Y_pi) + sizeof(this->W)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->k1) + sizeof(this->k2) + sizeof(this->Y_pi) + sizeof(this->W)) * baseNum;
+	}
+};
+Receiver R;
+
+class Sender
+{
+private:
+	Element X[n] = { NULL };
+	Element B[alpha] = { NULL };
+	Element k1 = NULL;
+	Element k2 = NULL;
+	vector<Element> E{};
+	Element V[n + l] = { NULL };
+	vector<Element> V_pi{};
+	vector<Element> X_pi{};
+	vector<vector<Element>> P_b{};
+	vector<Element> T_b{};
+
+public:
+	void input_X()
+	{
+		getInput(this->X, n);
+		return;
+	}
+	void auto_input_X()
+	{
+		for (int i = 0; i < n; ++i)
+			this->X[i] = getRandom();
+		return;
+	}
+	void hash_from_X_to_B()
+	{
+		for (int i = 0; i < n; ++i)
+		{
+			int index = h(this->X[i], 1);
+			if (NULL != this->B[index])//如果已经有
+			{
+				int new_index = h(this->B[index], 2);//再次哈希
+				if (NULL == this->B[new_index])//如果没有冲突了
+					this->B[new_index] = this->B[index];
+			}
+			this->B[index] = this->X[i];
+		}
+		return;
+	}
+	void receive_k1(Element k1)
+	{
+		this->k1 = k1;
+		return;
+	}
+	void receive_k2(Element k2)
+	{
+		this->k2 = k2;
+		return;
+	}
+	void generate_E()
+	{
+		for (int i = 0; i < l; ++i)
+			this->E.push_back(getRandom());
+		legacyRandomShuffle(this->E.begin(), this->E.end());
+		legacyRandomShuffle(this->E.begin(), this->E.end());
+		return;
+	}
+	void rand_V()
+	{
+		for (int i = 0; i < alpha; ++i)
+			this->V[i] = getRandom();
+		return;
+	}
+	void shuffle_from_V_to_V_pi()
+	{
+		for (int i = 0; i < n + l; ++i)
+			this->V_pi.push_back(this->V[i]);
+		legacyRandomShuffle(this->V_pi.begin(), this->V_pi.end());
+		return;
+	}
+	void shuffle_from_X_to_X_pi()
+	{
+		for (int i = 0; i < n; ++i)
+			this->X_pi.push_back(this->X[i]);
+		for (int i = 0; i < l; ++i)
+			this->X_pi.push_back(this->E[i]);
+		legacyRandomShuffle(this->X_pi.begin(), this->X_pi.end());
+		return;
+	}
+	void generate_P_b()
+	{
+		for (int i = 0; i < alpha && this->P_b.size() < beta; ++i)
+		{
+			vector<Element> tmp{ this->X_pi[i], H(this->X_pi[i]) ^ this->V[i] };
+			if (find(this->P_b.begin(), this->P_b.end(), tmp) == this->P_b.end())
+				this->P_b.push_back(tmp);
+		}
+		return;
+	}
+	void generate_T_b()
+	{
+		for (size_t i = 0; i < this->P_b.size(); ++i)
+			this->T_b.push_back(encode(this->P_b[i][0], this->P_b[i][1]));
+		return;
+	}
+	vector<Element> send_T_b()
+	{
+		return this->T_b;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerS * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Sender) = " << sizeof(Sender) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".X) = " << sizeof(this->X) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".B) = " << sizeof(this->B) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".k1) = " << sizeof(this->k1) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".k2) = " << sizeof(this->k2) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".E) = " << sizeof(this->E) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".V) = " << sizeof(this->V) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".V_pi) = " << sizeof(this->V_pi) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".X_pi) = " << sizeof(this->X_pi) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".P_b) = " << sizeof(this->P_b) * baseNum << " B" << endl;
+		cout << "\tsizeof(" << eleName << ".T_b) = " << sizeof(this->T_b) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->k1) + sizeof(this->k2) + sizeof(this->T_b)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->k1) + sizeof(this->k2) + sizeof(this->T_b)) * baseNum;
+	}
+};
+Sender S;
+
+class Cloud
+{
+private:
+	vector<Element> T_b{};
+	vector<Element> Y_pi{};
+	Element omega_b[alpha] = { NULL };
+	vector<Element> W = { NULL };
+
+public:
+	void receive_T_b(vector<Element> T_b)
+	{
+		this->T_b.assign(T_b.begin(), T_b.end());
+		return;
+	}
+	void receive_Y_pi(vector<Element> Y_pi)
+	{
+		this->Y_pi.assign(Y_pi.begin(), Y_pi.end());
+		return;
+	}
+	void compute_omega_b()
+	{
+		for (int i = 0; i < alpha; ++i)
+			this->omega_b[i] = decode(this->T_b[i % this->T_b.size()], this->Y_pi[i]);
+		return;
+	}
+	void rand_W()
+	{
+		for (int i = 0; i < alpha; ++i)
+			this->W.push_back(this->omega_b[i]);
+		legacyRandomShuffle(this->W.begin(), this->W.end());
+		return;
+	}
+	vector<Element> send_W()
+	{
+		return this->W;
+	}
+	size_t printSize(string eleName, bool /* isToFile */)
+	{
+		cout << "Timeof(" << eleName << ") = " << timerC * baseNum * 1000.0 / CLOCKS_PER_SEC / configuredRunCount << " ms" << endl;
+		cout << "sizeof(Cloud) = " << sizeof(Cloud) * baseNum << " B" << endl;
+		cout << "sizeof(" << eleName << ") = " << sizeof(this) * baseNum << " KB" << endl;
+		cout << "\tsizeof(" << eleName << ".T_b) = " << sizeof(this->T_b) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".Y_pi) = " << sizeof(this->Y_pi) * baseNum << " B (*)" << endl;
+		cout << "\tsizeof(" << eleName << ".*) = " << (sizeof(this->T_b) + sizeof(this->Y_pi)) * baseNum << " B (*)" << endl;
+		return (sizeof(this->T_b) + sizeof(this->Y_pi)) * baseNum;
+	}
+};
+Cloud C;
+
+
+/* 子函数 */
+void input(bool isAuto)
+{
+	if (isAuto)
+	{
+		S.auto_input_X();
+		R.auto_input_Y();
+	}
+	else
+	{
+		S.input_X();
+		R.input_Y();
+	}
+	return;
+}
+
+void protocol()
+{
+	sub_start_time = clock(); 	R.rand_k1();														sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.rand_k2();														sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.hash_from_Y_to_B();												sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.hash_from_X_to_B();												sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.receive_k1(R.send_k1());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.receive_k2(R.send_k2());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.generate_E();														sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.rand_V();															sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.shuffle_from_V_to_V_pi();											sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.shuffle_from_X_to_X_pi();											sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.generate_P_b();													sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	S.generate_T_b();													sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C.receive_T_b(S.send_T_b());										sub_end_time = clock(); timerS += (double)sub_end_time - sub_start_time + adjust; timerC += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.generate_E();														sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.shuffle_from_Y_to_Y_pi();											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C.receive_Y_pi(R.send_Y_pi());										sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C.compute_omega_b();												sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	C.rand_W();															sub_end_time = clock(); timerC += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.receive_W(C.send_W());											sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust; timerC += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	cout << "verify = " << (R.verify() ? "true" : "false") << endl;		sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.rand_V();															sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	sub_start_time = clock(); 	R.printIntersection();												sub_end_time = clock(); timerR += (double)sub_end_time - sub_start_time + adjust;
+	return;
+}
+
+
+
+/* main 函数 */
+void test()
+{
+	input(true);
+	protocol();
+	return;
+}
+
+int main(int argc, char* argv[])
+{
+	Parser parser(argc, argv, "VPSI-CA-Alg5");
+	const ParserOptions options = parser.parse();
+	if (options.flag <= 0)
+	{
+		return finishExecution(options.waitingTime, options.decimalPlace, options.flag == 0 ? EXIT_SUCCESS : -1);
+	}
+
+	configuredRunCount = options.runCount;
+	double elapsedCpuMilliseconds = 0.0;
+	double spaceKilobytes = 0.0;
+	{
+		ScopedOutputSilencer silencer(cout, options.quiet);
+		const clock_t start_time = clock();
+		for (std::size_t i = 0U; i < options.runCount; ++i)
+		{
+			cout << "/**************************************** Time: " << i + 1U << " ****************************************/" << endl;
+			test();
+			cout << endl << endl;
+		}
+		const clock_t end_time = clock();
+		elapsedCpuMilliseconds = (static_cast<double>(end_time - start_time) + static_cast<double>(adjust)) * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / static_cast<double>(options.runCount);
+		cout << endl;
+		cout << "/**************************************** VPSI-CA Alg. 5 ****************************************/" << endl;
+		cout << "kBit = " << kBit << "\t\tm = 2 ** " << m << "\t\tn = 2 ** " << n << "\t\tl = 2 ** " << l << endl;
+		cout << "Time: " << elapsedCpuMilliseconds << " ms" << endl;
+		spaceKilobytes = static_cast<double>(R.printSize("R", false) + S.printSize("S", false) + C.printSize("C", false)) / 1024.0;
+		cout << "sizeof(*) = " << spaceKilobytes << " KB (*)" << endl << endl;
+	}
+
+	const double divisor = static_cast<double>(options.runCount);
+	const double receiverCpuMilliseconds = timerR * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double senderCpuMilliseconds = timerS * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	const double cloudCpuMilliseconds = timerC * static_cast<double>(baseNum) * 1000.0 / CLOCKS_PER_SEC / divisor;
+	Saver saver(
+		options.outputPath,
+		{"scheme", "kBit", "m", "n", "l", "beta", "runCount", "elapsedCpuMilliseconds", "receiverCpuMilliseconds", "senderCpuMilliseconds", "cloudCpuMilliseconds", "spaceKilobytes"},
+		options.decimalPlace,
+		options.overwriteConfirmed);
+	const SaverRow row = {
+		std::string("VPSI-CA-Alg5"), std::uint64_t{kBit}, std::uint64_t{m}, std::uint64_t{n}, std::uint64_t{l}, std::uint64_t{beta},
+		static_cast<std::uint64_t>(options.runCount), elapsedCpuMilliseconds, receiverCpuMilliseconds, senderCpuMilliseconds, cloudCpuMilliseconds, spaceKilobytes};
+	const int exitCode = saver.save({row}) ? EXIT_SUCCESS : EXIT_FAILURE;
+	return finishExecution(options.waitingTime, options.decimalPlace, exitCode);
+}

--- a/README.md
+++ b/README.md
@@ -51,12 +51,21 @@ We are currently merging cryptographic schemes from our other repositories. Cryp
   - [FS-MUAEKS.py](./FS-MUAEKS/FS-MUAEKS.py)
 - [LB-PEAKS](./LB-PEAKS/)
   - [LB-PEAKS.py](./LB-PEAKS/LB-PEAKS.py)
+- [PSI-CA](./PSI-CA/)
+  - [OPSI-CA.cpp](./PSI-CA/OPSI-CA.cpp)
+  - [PSI-CA.cpp](./PSI-CA/PSI-CA.cpp)
+  - [SPSI-CA(1).cpp](./PSI-CA/SPSI-CA(1).cpp)
+  - [VPSI-CA-Alg2.cpp](./PSI-CA/VPSI-CA-Alg2.cpp)
+  - [VPSI-CA-Alg3.cpp](./PSI-CA/VPSI-CA-Alg3.cpp)
+  - [VPSI-CA-Alg4.cpp](./PSI-CA/VPSI-CA-Alg4.cpp)
+  - [VPSI-CA-Alg5.cpp](./PSI-CA/VPSI-CA-Alg5.cpp)
 
 Most of the cryptographic schemes here are pairing-based, which are implemented based on the PBC library and its variants. 
 
 | Programming language | Dependency |
 | - | - |
-| C/C++ | [PBC](https://crypto.stanford.edu/pbc/download.html) |
+| C++ (PSI-CA) | C++17 standard library for algorithms and formatting; Ubuntu/POSIX APIs for file publication (Windows compilation is rejected); no third-party libraries |
+| C (and pairing-based C/C++) | [PBC](https://crypto.stanford.edu/pbc/download.html) |
 | Python (3.12 or above) | [Python Charm-Crypto framework](https://github.com/JHUISI/charm) |
 | Java | JPBC |
 
@@ -1007,7 +1016,62 @@ Therefore, this repository only contains the up-to-date Java implementation, wit
 Please use an external memory monitor (such as the Task Manager) to record memory information (e.g., peak RSS) for each Java implementation if necessary. 
 Meanwhile, space measurements other than the computation of the object length will not be officially offered in this repository. 
 
-## 3. Acknowledgment
+## 3. C++
+
+The seven implementations under [``PSI-CA``](./PSI-CA/) are standalone C++17 programs. Their algorithms and result formatting use the C++17 standard library, and they use no third-party libraries. The saver's file-publication path uses Ubuntu/POSIX APIs, so these implementations target Ubuntu/POSIX and compilation on Windows is rejected. These files do not require PBC or the pairing-based dependencies used by other C/C++ implementations in this repository.
+
+### 3.1 C++ environment, inputs, and outputs
+
+The programs are developed for Ubuntu and require a compiler such as ``g++`` with C++17 support. From the repository root, the following example uses all required warning flags; the quotes protect the parentheses in the source name, and the output binary is placed under ``PSI-CA``.
+
+```shell
+g++ -std=c++17 -Wall -Wextra -Wpedantic "PSI-CA/SPSI-CA(1).cpp" -o "PSI-CA/SPSI-CA(1)"
+```
+
+A noninteractive execution that selects the output, precision, run count, immediate exit, and overwrite authorization is as follows.
+
+```shell
+"PSI-CA/SPSI-CA(1)" -o "results.csv" -p 9 -r 10 -t 0 -y
+```
+
+All aliases in the following table are case-insensitive. Pass ``-h`` to print the exact short option list.
+
+| Purpose | Accepted aliases |
+| - | - |
+| Encoding | ``e``, ``/e``, ``-e``, ``encoding``, ``/encoding``, ``--encoding`` |
+| Help | ``h``, ``/h``, ``-h``, ``help``, ``/help``, ``--help`` |
+| Output path | ``o``, ``/o``, ``-o``, ``output``, ``/output``, ``--output`` |
+| Decimal place | ``p``, ``/p``, ``-p``, ``place``, ``/place``, ``--place`` |
+| Quiet mode | ``q``, ``/q``, ``-q``, ``quiet``, ``/quiet``, ``--quiet`` |
+| Run count | ``r``, ``/r``, ``-r``, ``run``, ``/run``, ``--run`` |
+| Waiting time | ``t``, ``/t``, ``-t``, ``time``, ``/time``, ``--time`` |
+| Overwrite confirmation | ``y``, ``/y``, ``-y``, ``yes``, ``/yes``, ``--yes`` |
+
+Only UTF-8 (``UTF-8`` or ``UTF8``) is accepted for the encoding. The default output is ``<program>.csv``, the default decimal place is 9, the default run count is 10, and the default waiting time is infinity. These seven entry points use noninteractive parser and exit handling, so the infinite default does not pause for terminal input; specify ``-t 0`` to make immediate exit explicit in scripts.
+
+A relative output path is resolved against the executable's directory, not the current working directory. If ``-o`` names a directory path (an existing directory or a path ending in a directory separator), the program appends its default ``<program>.csv`` file name. If parsing produces a protected source or script extension, that extension is reset to ``.csv``; the saver independently rejects a protected extension if one reaches it directly.
+
+An existing output requires ``-y`` in these noninteractive programs or interactive confirmation when the shared parser is embedded with interactive input enabled. On Ubuntu/POSIX, after opening and validating the output parent directory, the saver creates an owner-only private workspace and performs its workspace and publication steps with directory-FD-anchored ``mkdirat``, ``openat``, ``linkat``, ``renameat``, and ``unlinkat`` operations. It uses ``linkat`` for atomic no-clobber directory-entry publication and ``renameat`` for authorized replacement. The saver rejects symlink and non-regular targets. Saving is not crash-durable because the saver does not call ``fsync``. These statements describe the implemented publication mechanics, not a general security guarantee.
+
+CSV, TSV, and TXT are the supported output formats, with CSV as the default. An unsupported extension retains the requested file name but receives escaped TXT content as a fallback. Decimal values use the requested precision, while integers are written without decimal places.
+
+The exit codes describe parsing and saving rather than cryptographic validation. ``EXIT_SUCCESS`` ($0$) is returned when the result is saved, and ``EXIT_FAILURE`` ($1$) is returned when saving fails. For invalid arguments, ``main`` returns the literal ``-1`` (normally observed as $255$ on POSIX shells). Help exits with ``EXIT_SUCCESS`` ($0$). The algorithms currently do not expose a separate correctness boolean to ``main``, so cryptographic correctness does not independently determine these exit codes.
+
+The [``runCPP`` workflow](./.github/workflows/runCPP.yml) runs an exact seven-program matrix on ``ubuntu-latest``. Its checkout and artifact actions are pinned to full commit SHAs. Every program is compiled with ``-std=c++17 -Wall -Wextra -Wpedantic``, then exercised with both a help command and a real execution, and the generated results are uploaded as artifacts. Manual dispatch accepts the output format, decimal place, and run count. The CI run count is limited to 1 through 100; an absent or invalid value falls back to 10. Each matrix job has a 30-minute timeout.
+
+### 3.2 Time complexity
+
+The implementations retain their original measurement model. They take CPU-clock samples with ``clock()``, subtract the starting tick count from the ending tick count, and divide by ``CLOCKS_PER_SEC`` while multiplying by 1000 to report milliseconds. Results are divided by the selected run count to obtain a per-run average.
+
+The original ``baseNum`` scaling remains part of both total and actor-specific measurements. The VPSI variants also retain their per-operation ``adjust`` terms. OPSI and SPSI retain the actor-specific modeled costs added to the measured sender and cloud totals. These values therefore reproduce the programs' academic cost model and should not be interpreted as unadjusted wall-clock benchmarks.
+
+### 3.3 Space complexity
+
+The space outputs preserve the academic formulas implemented by each class's ``printSize`` method. OPSI-CA, PSI-CA, and SPSI-CA report bytes. The VPSI-CA programs sum the ``printSize`` results as aggregate byte totals, divide them by ``1024.0``, and save the fractional results as kilobytes. The formulas scale selected elements and collections according to the scheme parameters and retain the original program-specific aggregation.
+
+These values are serialized or object-model estimates for the selected scheme objects, not measurements of process RSS or peak resident memory. Use an external memory monitor when peak memory consumption is required.
+
+## 4. Acknowledgment
 
 We extend our sincere gratitude to the developers for their diligent efforts. Without their assistance, this repository would not exist. 
 

--- a/docs/superpowers/plans/2026-08-03-psi-ca-cpp-integration.md
+++ b/docs/superpowers/plans/2026-08-03-psi-ca-cpp-integration.md
@@ -1,0 +1,171 @@
+# PSI-CA C++ Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the seven supplied PSI-CA C++ programs, give every program a Python/Java-style command-line parser and result saver, run every program in GitHub Actions, and document C++ as README section 3.
+
+**Architecture:** Keep the seven algorithms as independent translation units under `PSI-CA/`. Put the shared standard-library-only `Parser`, `Saver`, option/result value types, and exit-wait helper in `PSI-CA/ParserSaver.hpp`, then include that header from every program. Save CSV, TSV, or TXT without third-party libraries and resolve relative output paths against the executable directory.
+
+**Tech Stack:** C++17 standard library, GNU g++, Bash, GitHub Actions YAML, Markdown.
+
+---
+
+### Task 1: Import the seven supplied programs
+
+**Files:**
+- Create: `PSI-CA/OPSI-CA.cpp`
+- Create: `PSI-CA/PSI-CA.cpp`
+- Create: `PSI-CA/SPSI-CA(1).cpp`
+- Create: `PSI-CA/VPSI-CA-Alg2.cpp`
+- Create: `PSI-CA/VPSI-CA-Alg3.cpp`
+- Create: `PSI-CA/VPSI-CA-Alg4.cpp`
+- Create: `PSI-CA/VPSI-CA-Alg5.cpp`
+- Create: `tests/cpp/runCPPRegressionTest.sh`
+
+- [ ] **Step 1: Write the failing source-inventory test**
+
+Create a shell test that declares the exact seven expected file names, checks that each exists under `PSI-CA/`, and fails with the missing path.
+
+- [ ] **Step 2: Run the inventory test and verify RED**
+
+Run: `bash tests/cpp/runCPPRegressionTest.sh`
+
+Expected: FAIL because `PSI-CA/OPSI-CA.cpp` does not exist.
+
+- [ ] **Step 3: Copy the supplied files without changing their algorithms**
+
+Copy the exact files from `/Users/felix_project/yuers/cpp/` into `PSI-CA/`, preserving all seven names.
+
+- [ ] **Step 4: Run the inventory test and verify GREEN**
+
+Run: `bash tests/cpp/runCPPRegressionTest.sh`
+
+Expected: PASS for the inventory section.
+
+### Task 2: Implement the shared Parser and Saver
+
+**Files:**
+- Create: `PSI-CA/ParserSaver.hpp`
+- Create: `tests/cpp/ParserSaverTest.cpp`
+- Modify: `tests/cpp/runCPPRegressionTest.sh`
+
+- [ ] **Step 1: Write failing Parser/Saver contract tests**
+
+The C++ test must instantiate `Parser` with mixed-case aliases, verify `-o`, `-p`, `-q`, `-r`, `-t`, and `-y`, confirm relative output paths use the executable directory, reject protected output extensions, and verify CSV quoting plus decimal formatting from `Saver`.
+
+- [ ] **Step 2: Run the contract test and verify RED**
+
+Run: `g++ -std=c++17 -Wall -Wextra -Wpedantic tests/cpp/ParserSaverTest.cpp -o /tmp/ParserSaverTest`
+
+Expected: FAIL because `PSI-CA/ParserSaver.hpp` does not exist.
+
+- [ ] **Step 3: Implement the minimal standard-library header**
+
+Define `ParserOptions`, `Parser`, `SaverValue`, `Saver`, and `finishExecution`. Match the Python/Java aliases for encoding, help, output, decimal place, quiet mode, run count, waiting time, and overwrite confirmation. Limit encoding to UTF-8, support CSV/TSV/TXT, create parent directories, and never overwrite an existing file without `-y` or interactive confirmation.
+
+- [ ] **Step 4: Run the contract test and verify GREEN**
+
+Run: `g++ -std=c++17 -Wall -Wextra -Wpedantic tests/cpp/ParserSaverTest.cpp -o /tmp/ParserSaverTest && /tmp/ParserSaverTest`
+
+Expected: exit 0 with no diagnostics.
+
+### Task 3: Connect every algorithm to Parser and Saver
+
+**Files:**
+- Modify: all seven `PSI-CA/*.cpp` files
+- Modify: `tests/cpp/runCPPRegressionTest.sh`
+
+- [ ] **Step 1: Extend the regression test and verify RED**
+
+For every source, require `#include "ParserSaver.hpp"`, `int main(int argc, char* argv[])`, a `Parser` instance, a `Saver` instance, and use of parsed run count instead of `TimeToTest` in execution and average-result calculations.
+
+- [ ] **Step 2: Add minimal per-program integration**
+
+Parse options at the start of `main`, support help/invalid-argument exits, honor quiet mode, execute the requested run count, save one summary row with scheme parameters, elapsed CPU milliseconds, actor timers, and space size, and call `finishExecution` for `-t` behavior. Replace the four legacy `dump` functions with `Saver` calls.
+
+- [ ] **Step 3: Compile all sources with the CI flags**
+
+Run: `find PSI-CA -maxdepth 1 -type f -name '*.cpp' -print0 | while IFS= read -r -d '' source; do g++ -std=c++17 -Wall -Wextra -Wpedantic "$source" -o "/tmp/$(basename "${source%.cpp}")"; done`
+
+Expected: seven successful compilations. Existing algorithm warnings may remain because the requested flags do not include `-Werror`.
+
+- [ ] **Step 4: Execute all sources through the regression test**
+
+Run every binary with `-q -r 1 -t 0 -y -o <temporary CSV>`, require exit 0, require a non-empty result file, and validate a CSV header and data row.
+
+Expected: seven successful executions and seven result files.
+
+### Task 4: Add the C++ GitHub Actions workflow
+
+**Files:**
+- Create: `.github/workflows/runCPP.yml`
+- Modify: `tests/cpp/runCPPRegressionTest.sh`
+
+- [ ] **Step 1: Add failing workflow assertions**
+
+Require pull-request, push, and workflow-dispatch triggers; an exact seven-file matrix; compilation containing `g++ -std=c++17 -Wall -Wextra -Wpedantic`; execution with parser options; and artifact upload.
+
+- [ ] **Step 2: Run the assertions and verify RED**
+
+Run: `bash tests/cpp/runCPPRegressionTest.sh`
+
+Expected: FAIL because `.github/workflows/runCPP.yml` does not exist.
+
+- [ ] **Step 3: Implement `runCPP.yml`**
+
+Model its inputs and preparation steps after `runJava.yml` and `runPython.yml`. Use an exact matrix of seven source paths, compile each source to a temporary binary with the required warning flags, run help, execute with output/precision/run/time/overwrite arguments, and upload each CSV output.
+
+- [ ] **Step 4: Validate workflow syntax and assertions**
+
+Parse the YAML with the available Python YAML library when present and rerun the shell regression test.
+
+Expected: workflow assertions pass and YAML parsing succeeds.
+
+### Task 5: Document C++ as README section 3
+
+**Files:**
+- Modify: `README.md`
+- Modify: `tests/cpp/runCPPRegressionTest.sh`
+
+- [ ] **Step 1: Add failing README assertions**
+
+Require `## 3. C++`, environment/build instructions, Parser arguments, CSV/TSV/TXT Saver formats, exit codes, and a `runCPP.yml` link; require Acknowledgment to become section 4.
+
+- [ ] **Step 2: Run assertions and verify RED**
+
+Run: `bash tests/cpp/runCPPRegressionTest.sh`
+
+Expected: FAIL because section 3 is currently Acknowledgment.
+
+- [ ] **Step 3: Update README**
+
+Add the seven C++ files to the repository inventory, insert section 3 after Java, explain Ubuntu/g++ requirements, give build/run examples with quoted paths, document the standard-library-only output formats and command-line defaults, link the workflow, explain timing/space output, and renumber Acknowledgment to section 4.
+
+- [ ] **Step 4: Run README assertions and inspect the diff**
+
+Run: `bash tests/cpp/runCPPRegressionTest.sh && git diff --check`
+
+Expected: PASS and no whitespace errors.
+
+### Task 6: Final verification
+
+**Files:**
+- Verify all changed files
+
+- [ ] **Step 1: Run the complete regression test from a clean temporary output directory**
+
+Run: `bash tests/cpp/runCPPRegressionTest.sh`
+
+Expected: PASS for all seven files.
+
+- [ ] **Step 2: Inspect repository state and diff**
+
+Run: `git status --short && git diff --stat && git diff --check`
+
+Expected: only intended PSI-CA, workflow, README, tests, and plan changes; no generated binaries or result files.
+
+- [ ] **Step 3: Commit the completed change**
+
+Run: `git add .github/workflows/runCPP.yml README.md PSI-CA tests/cpp docs/superpowers/plans/2026-08-03-psi-ca-cpp-integration.md && git commit -m "Add PSI-CA C++ workflow support"`
+
+Expected: one English commit on `codex/add-psi-ca-cpp`.

--- a/tests/cpp/ParserSaverTest.cpp
+++ b/tests/cpp/ParserSaverTest.cpp
@@ -1,0 +1,604 @@
+#include "../../PSI-CA/ParserSaver.hpp"
+
+#include <chrono>
+#include <clocale>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
+namespace
+{
+	static_assert(
+		sizeof(ScopedOutputSilencer) < sizeof(std::ostringstream),
+		"ScopedOutputSilencer must use a non-retaining discard buffer.");
+
+	int failures = 0;
+
+	void expect(const bool condition, const std::string &message)
+	{
+		if (!condition)
+		{
+			std::cerr << "FAIL: " << message << '\n';
+			++failures;
+		}
+	}
+
+	std::string readFile(const std::filesystem::path &path)
+	{
+		std::ifstream input(path, std::ios::binary);
+		return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+	}
+
+	bool hasSaverTemporaryArtifact(const std::filesystem::path &root)
+	{
+		std::error_code error;
+		std::filesystem::recursive_directory_iterator iterator(root, error);
+		if (error)
+		{
+			throw std::runtime_error("Could not inspect test artifacts: " + error.message());
+		}
+		const std::filesystem::recursive_directory_iterator end;
+		while (iterator != end)
+		{
+			const std::string filename = iterator->path().filename().string();
+			if (filename.rfind(".parser-saver-", 0U) == 0U)
+			{
+				return true;
+			}
+			iterator.increment(error);
+			if (error)
+			{
+				throw std::runtime_error("Could not inspect test artifacts: " + error.message());
+			}
+		}
+		return false;
+	}
+
+	std::size_t countOpenDescriptors()
+	{
+		std::size_t count = 0U;
+		for (int descriptor = 0; descriptor < 1024; ++descriptor)
+		{
+			if (::fcntl(descriptor, F_GETFD) != -1)
+			{
+				++count;
+			}
+		}
+		return count;
+	}
+
+	class Arguments
+	{
+	public:
+		explicit Arguments(std::vector<std::string> values) : values_(std::move(values))
+		{
+			for (std::string &value : values_)
+			{
+				pointers_.push_back(value.data());
+			}
+		}
+
+		int count() const
+		{
+			return static_cast<int>(pointers_.size());
+		}
+
+		char **data()
+		{
+			return pointers_.data();
+		}
+
+	private:
+		std::vector<std::string> values_;
+		std::vector<char *> pointers_;
+	};
+
+	class TemporaryDirectory
+	{
+	public:
+		TemporaryDirectory()
+		{
+			static std::uint64_t counter = 0U;
+			for (std::uint64_t attempt = 0U; attempt < 1000U; ++attempt)
+			{
+				const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+				path_ = std::filesystem::temp_directory_path() / ("parser_saver_cpp_test_" + std::to_string(timestamp) + "_" + std::to_string(++counter));
+				std::error_code error;
+				if (std::filesystem::create_directory(path_, error))
+				{
+					return;
+				}
+				if (error && error != std::errc::file_exists)
+				{
+					throw std::runtime_error("Could not create test directory: " + error.message());
+				}
+			}
+			throw std::runtime_error("Could not allocate a unique test directory.");
+		}
+
+		~TemporaryDirectory()
+		{
+			std::error_code error;
+			std::filesystem::remove_all(path_, error);
+		}
+
+		TemporaryDirectory(const TemporaryDirectory &) = delete;
+		TemporaryDirectory &operator=(const TemporaryDirectory &) = delete;
+
+		const std::filesystem::path &path() const
+		{
+			return path_;
+		}
+
+	private:
+		std::filesystem::path path_;
+	};
+
+	class ScopedUmask
+	{
+	public:
+		explicit ScopedUmask(const mode_t mask) : previous_(::umask(mask))
+		{
+		}
+
+		~ScopedUmask()
+		{
+			::umask(previous_);
+		}
+
+		ScopedUmask(const ScopedUmask &) = delete;
+		ScopedUmask &operator=(const ScopedUmask &) = delete;
+
+	private:
+		mode_t previous_;
+	};
+
+	ParserOptions parse(
+		std::vector<std::string> arguments,
+		const std::string &schemeName,
+		std::istream &input,
+		std::ostream &output,
+		std::ostream &error,
+		const bool interactiveInput = false)
+	{
+		Arguments values(std::move(arguments));
+		Parser parser(values.count(), values.data(), schemeName, interactiveInput, input, output, error);
+		return parser.parse();
+	}
+
+	void testParserDefaultsAndAliases(const std::filesystem::path &root)
+	{
+		std::istringstream input;
+		std::ostringstream output;
+		std::ostringstream error;
+		const std::filesystem::path executable = root / "bin" / "tool";
+		std::filesystem::create_directories(executable.parent_path());
+
+		const ParserOptions defaults = parse({executable.string()}, "Demo", input, output, error);
+		expect(defaults.flag == 1, "default parse succeeds");
+		expect(defaults.encoding == "utf-8", "encoding defaults to UTF-8");
+		expect(defaults.outputPath == (executable.parent_path() / "Demo.csv").lexically_normal(), "default output is beside executable");
+		expect(defaults.decimalPlace == 9, "decimal place defaults to nine");
+		expect(!defaults.quiet, "quiet defaults to false");
+		expect(defaults.runCount == 10U, "run count defaults to ten");
+		expect(std::isinf(defaults.waitingTime), "waiting time defaults to infinity");
+		expect(!defaults.overwriteConfirmed, "overwrite defaults to false");
+
+		const ParserOptions aliases = parse(
+			{executable.string(), "/EnCoDiNg", "UTF8", "--OuTpUt", "results/MiXeD.CsV", "/PlAcE", "microsecond", "--QuIeT", "/RuN", "7", "--TiMe", "1.25", "/YeS"},
+			"Demo",
+			input,
+			output,
+			error);
+		expect(aliases.flag == 1, "mixed-case long aliases parse");
+		expect(aliases.encoding == "utf-8", "UTF8 spelling is accepted");
+		expect(aliases.outputPath == (executable.parent_path() / "results" / "MiXeD.CsV").lexically_normal(), "relative output uses executable directory");
+		expect(aliases.decimalPlace == 6, "place translation parses");
+		expect(aliases.quiet, "quiet alias parses");
+		expect(aliases.runCount == 7U, "run count parses");
+		expect(aliases.waitingTime == 1.25, "waiting time parses");
+		expect(aliases.overwriteConfirmed, "overwrite alias parses");
+
+		const ParserOptions shortOptions = parse(
+			{executable.string(), "-o", "short.tsv", "-p", "3", "-q", "-r", "2", "-t", "0", "-y"},
+			"Demo",
+			input,
+			output,
+			error);
+		expect(shortOptions.flag == 1 && shortOptions.decimalPlace == 3 && shortOptions.quiet && shortOptions.runCount == 2U && shortOptions.waitingTime == 0.0 && shortOptions.overwriteConfirmed, "all principal short options parse");
+	}
+
+	void testParserPathsAndValidation(const std::filesystem::path &root)
+	{
+		const std::filesystem::path executable = root / "app" / "runner";
+		const std::filesystem::path outputDirectory = executable.parent_path() / "reports";
+		std::filesystem::create_directories(outputDirectory);
+		std::istringstream input;
+		std::ostringstream output;
+		std::ostringstream error;
+
+		const ParserOptions directory = parse({executable.string(), "-o", "reports", "-y"}, "Scheme", input, output, error);
+		expect(directory.outputPath == outputDirectory / "Scheme.csv", "directory output appends default filename");
+
+		const ParserOptions protectedPath = parse({executable.string(), "-o", "source.CpP", "-y"}, "Scheme", input, output, error);
+		expect(protectedPath.outputPath == executable.parent_path() / "source.csv", "protected extension is reset to CSV");
+
+		const ParserOptions consoleOutput = parse({executable.string(), "-o", ""}, "Scheme", input, output, error);
+		expect(consoleOutput.flag == 1 && consoleOutput.outputPath.empty(), "empty output path selects console mode");
+
+		Arguments noArguments(std::vector<std::string>{});
+		Parser noArgvParser(0, noArguments.data(), "NoArgv", false, input, output, error);
+		const ParserOptions noArgv = noArgvParser.parse();
+		expect(noArgv.outputPath == (std::filesystem::current_path() / "NoArgv.csv").lexically_normal(), "argc zero places default output in the current directory");
+
+		std::ostringstream helpOutput;
+		const ParserOptions help = parse({executable.string(), "/H"}, "Scheme", input, helpOutput, error);
+		expect(help.flag == 0 && helpOutput.str().find("Usage") != std::string::npos, "help returns zero and prints usage");
+
+		const std::vector<std::vector<std::string>> invalidArguments = {
+			{executable.string(), "-o"},
+			{executable.string(), "-e", "latin1"},
+			{executable.string(), "-p", "unknown"},
+			{executable.string(), "-p", "-1"},
+			{executable.string(), "-p", "19"},
+			{executable.string(), "-p", "999999999999999999999999999999"},
+			{executable.string(), "-r", "0"},
+			{executable.string(), "-r", "abc"},
+			{executable.string(), "-t", "-0.1"},
+			{executable.string(), "--mystery"}};
+		for (const std::vector<std::string> &arguments : invalidArguments)
+		{
+			std::ostringstream diagnostic;
+			const ParserOptions invalid = parse(arguments, "Scheme", input, output, diagnostic);
+			expect(invalid.flag < 0, "invalid or missing option value returns a negative flag");
+			expect(!diagnostic.str().empty(), "invalid option emits a diagnostic");
+		}
+		const ParserOptions maximumPlace = parse({executable.string(), "-p", "18"}, "Scheme", input, output, error);
+		expect(maximumPlace.flag == 1 && maximumPlace.decimalPlace == Parser::MAX_DECIMAL_PLACE, "maximum decimal precision is accepted");
+
+		const std::string longFilename(300U, 'a');
+		std::ostringstream longPathDiagnostic;
+		const ParserOptions longPath = parse({executable.string(), "-o", longFilename}, "Scheme", input, output, longPathDiagnostic);
+		expect(longPath.flag < 0 && !longPathDiagnostic.str().empty(), "filesystem inspection errors return a negative flag and diagnostic");
+
+		const ParserOptions infiniteTime = parse({executable.string(), "-t", "inf"}, "Scheme", input, output, error);
+		expect(infiniteTime.flag == 1 && std::isinf(infiniteTime.waitingTime), "time parser accepts infinity explicitly");
+		const char *const currentLocale = std::setlocale(LC_NUMERIC, nullptr);
+		const std::string savedLocale = currentLocale == nullptr ? "C" : currentLocale;
+		const std::vector<const char *> localeCandidates = {"de_DE.UTF-8", "de_DE.utf8", "fr_FR.UTF-8", "fr_FR.utf8"};
+		for (const char *candidate : localeCandidates)
+		{
+			const char *const selected = std::setlocale(LC_NUMERIC, candidate);
+			if (selected != nullptr && std::string(selected) != "C")
+			{
+				const ParserOptions localeIndependent = parse({executable.string(), "-t", "1.5"}, "Scheme", input, output, error);
+				expect(localeIndependent.flag == 1 && localeIndependent.waitingTime == 1.5, "time parsing uses the classic locale");
+				break;
+			}
+		}
+		std::setlocale(LC_NUMERIC, savedLocale.c_str());
+
+		const std::filesystem::path existing = executable.parent_path() / "existing.csv";
+		std::filesystem::create_directories(existing.parent_path());
+		{
+			std::ofstream file(existing);
+			file << "old";
+		}
+		std::istringstream noAnswer("no\n");
+		ParserOptions denied = parse({executable.string(), "-o", "existing.csv"}, "Scheme", noAnswer, output, error, true);
+		expect(denied.flag < 0 && !denied.overwriteConfirmed, "existing output is denied without affirmative confirmation");
+		std::istringstream yesAnswer("YeS\n");
+		ParserOptions confirmed = parse({executable.string(), "-o", "existing.csv"}, "Scheme", yesAnswer, output, error, true);
+		expect(confirmed.flag == 1 && confirmed.overwriteConfirmed, "interactive yes permits overwrite");
+		std::istringstream pipedYes("yes\n");
+		ParserOptions noninteractive = parse({executable.string(), "-o", "existing.csv"}, "Scheme", pipedYes, output, error);
+		expect(noninteractive.flag < 0 && !noninteractive.overwriteConfirmed, "noninteractive input never authorizes overwrite");
+		expect(pipedYes.peek() == 'y', "noninteractive overwrite check does not read piped input");
+	}
+
+	void testExecutablePathResolution(const std::filesystem::path &root)
+	{
+		const std::filesystem::path currentDirectory = root / "working";
+		const std::filesystem::path firstPathEntry = root / "first-bin";
+		const std::filesystem::path secondPathEntry = root / "second-bin";
+		std::filesystem::create_directories(currentDirectory);
+		std::filesystem::create_directories(firstPathEntry);
+		std::filesystem::create_directories(secondPathEntry);
+		{
+			std::ofstream executable(firstPathEntry / "bare-tool");
+			executable << "not executable";
+		}
+		{
+			std::ofstream executable(secondPathEntry / "bare-tool");
+			executable << "tool";
+		}
+		std::error_code permissionError;
+		std::filesystem::permissions(
+			firstPathEntry / "bare-tool",
+			std::filesystem::perms::group_exec,
+			std::filesystem::perm_options::replace,
+			permissionError);
+		expect(!permissionError, "non-executable PATH fixture permissions are applied");
+		std::filesystem::permissions(
+			secondPathEntry / "bare-tool",
+			std::filesystem::perms::owner_read | std::filesystem::perms::owner_write | std::filesystem::perms::owner_exec,
+			std::filesystem::perm_options::replace,
+			permissionError);
+		expect(!permissionError, "executable PATH fixture permissions are applied");
+		const std::string searchPath = firstPathEntry.string() + ":" + secondPathEntry.string();
+#if defined(_WIN32)
+		const std::filesystem::path expectedPathDirectory = firstPathEntry;
+#else
+		expect(::access((firstPathEntry / "bare-tool").c_str(), X_OK) != 0, "group-only execute mode is not executable by the owning user");
+		const std::filesystem::path expectedPathDirectory = secondPathEntry;
+#endif
+		expect(
+			parser_saver_detail::resolveExecutableDirectory("bare-tool", currentDirectory, searchPath, ':') == expectedPathDirectory.lexically_normal(),
+			"bare argv zero resolves through the first executable PATH entry for the current identity");
+		expect(
+			parser_saver_detail::resolveExecutableDirectory("missing-tool", currentDirectory, searchPath, ':') == currentDirectory.lexically_normal(),
+			"missing bare argv zero falls back to the current directory");
+		expect(
+			parser_saver_detail::resolveExecutableDirectory("relative/bin/tool", currentDirectory, secondPathEntry.string(), ':') == (currentDirectory / "relative" / "bin").lexically_normal(),
+			"relative argv zero with a parent component does not use PATH");
+		const std::filesystem::path absoluteExecutable = root / "absolute" / "bin" / "tool";
+		expect(
+			parser_saver_detail::resolveExecutableDirectory(absoluteExecutable, currentDirectory, secondPathEntry.string(), ':') == absoluteExecutable.parent_path().lexically_normal(),
+			"absolute argv zero does not use PATH");
+	}
+
+	void testSaver(const std::filesystem::path &root)
+	{
+		const std::vector<std::string> columns = {"name", "value", "enabled", "empty"};
+		const std::vector<std::vector<SaverValue>> rows = {
+			{std::string("comma, quote \" and\nline"), 1.23456, true, std::monostate{}},
+			{std::string("plain"), std::int64_t{-7}, false, std::uint64_t{42}}};
+		std::ostringstream output;
+		std::ostringstream error;
+#if !defined(_WIN32)
+		int pipeDescriptors[2] = {-1, -1};
+		expect(::pipe(pipeDescriptors) == 0, "POSIX write helper test pipe is created");
+		std::error_code writeError;
+		const std::string descriptorPayload = "descriptor payload";
+		expect(parser_saver_detail::writeAllToDescriptor(pipeDescriptors[1], descriptorPayload, writeError) && !writeError, "descriptor helper writes the complete payload");
+		expect(::close(pipeDescriptors[1]) == 0, "POSIX write helper test closes its writer");
+		char descriptorBuffer[32] = {};
+		const ssize_t descriptorBytes = ::read(pipeDescriptors[0], descriptorBuffer, sizeof(descriptorBuffer));
+		expect(descriptorBytes == static_cast<ssize_t>(descriptorPayload.size()) && std::string(descriptorBuffer, static_cast<std::size_t>(descriptorBytes)) == descriptorPayload, "descriptor helper preserves payload bytes");
+		expect(::close(pipeDescriptors[0]) == 0, "POSIX write helper test closes its reader");
+		int closePipeDescriptors[2] = {-1, -1};
+		expect(::pipe(closePipeDescriptors) == 0, "checked close helper test pipe is created");
+		std::error_code closeError;
+		expect(parser_saver_detail::closeDescriptorChecked(closePipeDescriptors[1], closeError) && !closeError, "checked close helper closes an owned descriptor");
+		expect(::fcntl(closePipeDescriptors[1], F_GETFD) == -1 && errno == EBADF, "checked close helper relinquishes descriptor ownership after one close call");
+		expect(::close(closePipeDescriptors[0]) == 0, "checked close helper test closes its reader");
+#endif
+
+		const std::size_t descriptorsBeforeUmask = countOpenDescriptors();
+		const std::filesystem::path umaskPath = root / "umask-denied.csv";
+		Saver umaskSaver(umaskPath, {"value"}, 1, false, output, error);
+		bool umaskSaved = false;
+		{
+			const ScopedUmask restrictiveUmask(0777);
+			umaskSaved = umaskSaver.save({{std::string("blocked")}});
+		}
+		expect(!umaskSaved, "restrictive process umask produces an explicit save failure");
+		expect(!std::filesystem::exists(umaskPath) && !hasSaverTemporaryArtifact(root), "restrictive umask failure leaves no output or temporary artifact");
+		expect(countOpenDescriptors() == descriptorsBeforeUmask, "restrictive umask failure leaks no file descriptors");
+
+		const std::filesystem::path realParent = root / "real-parent";
+		const std::filesystem::path linkedParent = root / "linked-parent";
+		std::filesystem::create_directories(realParent);
+		std::error_code parentSymlinkError;
+		std::filesystem::create_directory_symlink(realParent, linkedParent, parentSymlinkError);
+		if (!parentSymlinkError)
+		{
+			Saver linkedParentSaver(linkedParent / "linked.csv", {"value"}, 1, false, output, error);
+			expect(linkedParentSaver.save({{std::string("saved")}}), "Saver accepts a legitimate final parent-directory symlink");
+			expect(readFile(realParent / "linked.csv") == "value\nsaved\n", "parent symlink output is anchored in the resolved directory");
+		}
+
+		const std::filesystem::path csvPath = root / "nested" / "data.CSV";
+		Saver csv(csvPath, columns, 3, false, output, error);
+		expect(csv.save(rows), "CSV save succeeds");
+		const std::string csvText = readFile(csvPath);
+		expect(csvText.find("\"comma, quote \"\" and\nline\"") != std::string::npos, "CSV special fields are quoted and quotes doubled");
+		expect(csvText.find("1.235") != std::string::npos, "double is formatted to configured places");
+		expect(csvText.find("-7.000") == std::string::npos && csvText.find(",-7,") != std::string::npos, "signed integer has no decimal suffix");
+		expect(csvText.find(",42\n") != std::string::npos, "unsigned integer has no decimal suffix");
+		expect(std::filesystem::is_directory(csvPath.parent_path()), "Saver creates parent directories");
+
+		const std::filesystem::path tsvPath = root / "data.tSv";
+		Saver tsv(tsvPath, {"field", "number"}, 2, false, output, error);
+		expect(tsv.save({{std::string("tab\there"), 2.0}}), "TSV save succeeds case-insensitively");
+		const std::string tsvText = readFile(tsvPath);
+		expect(tsvText.find("\"tab\there\"\t2.00") != std::string::npos, "TSV quoting and decimal formatting are correct");
+
+		const std::filesystem::path txtPath = root / "data.txt";
+		Saver txt(txtPath, {"left", "right"}, 1, false, output, error);
+		expect(txt.save({{std::string("alpha"), std::int64_t{9}}}), "TXT save succeeds");
+		expect(readFile(txtPath) == "left\tright\nalpha\t9\n", "TXT content is tab-separated and preserves integers");
+		const std::filesystem::path escapedTxtPath = root / "escaped.txt";
+		Saver escapedTxt(escapedTxtPath, {"value"}, 1, false, output, error);
+		expect(escapedTxt.save({{std::string("tab\tcr\rline\nslash\\")}}), "TXT save escapes structural characters");
+		expect(readFile(escapedTxtPath) == "value\ntab\\tcr\\rline\\nslash\\\\\n", "TXT escaping preserves row and column structure");
+
+		const std::filesystem::path fallbackPath = root / "data.bin";
+		Saver fallback(fallbackPath, {"value"}, 1, false, output, error);
+		expect(fallback.save({{std::string("text")}}), "unsupported extension falls back successfully");
+		expect(std::filesystem::exists(fallbackPath) && readFile(fallbackPath) == "value\ntext\n", "fallback preserves path and writes TXT content");
+		expect(output.str().find("TXT") != std::string::npos && output.str().find(fallbackPath.string()) != std::string::npos, "unsupported extension reports that TXT content was saved");
+
+		std::ostringstream table;
+		table << std::hex << std::setfill('*') << std::setprecision(4);
+		table.width(11);
+		const std::ios::fmtflags originalFlags = table.flags();
+		const char originalFill = table.fill();
+		const std::streamsize originalPrecision = table.precision();
+		const std::streamsize originalWidth = table.width();
+		Saver console({}, {"a", "b"}, 2, false, table, error);
+		expect(console.save({{std::int64_t{1}, 2.5}}), "empty output path prints a table");
+		expect(table.str().find("a") != std::string::npos && table.str().find("2.50") != std::string::npos, "printed table is readable and formatted");
+		expect(table.flags() == originalFlags && table.fill() == originalFill && table.precision() == originalPrecision && table.width() == originalWidth, "console table restores stream formatting state");
+
+		const std::filesystem::path existingPath = root / "existing-target.csv";
+		{
+			std::ofstream existing(existingPath);
+			existing << "original\n";
+		}
+		Saver unauthorized(existingPath, {"value"}, 1, false, output, error);
+		expect(!unauthorized.save({{std::string("replacement")}}), "Saver refuses an existing file without overwrite authorization");
+		expect(readFile(existingPath) == "original\n", "unauthorized save preserves existing content");
+		expect(!hasSaverTemporaryArtifact(root), "rejected save leaves no temporary artifact");
+		Saver authorized(existingPath, {"value"}, 1, true, output, error);
+		expect(authorized.save({{std::string("replacement")}}), "Saver replaces an existing regular file when authorized");
+		expect(readFile(existingPath) == "value\nreplacement\n", "authorized save installs complete replacement content");
+		expect(!hasSaverTemporaryArtifact(root), "successful save leaves no temporary artifact");
+		bool artifactInspectionFailed = false;
+		try
+		{
+			hasSaverTemporaryArtifact(root / "missing-artifact-root");
+		}
+		catch (const std::runtime_error &)
+		{
+			artifactInspectionFailed = true;
+		}
+		expect(artifactInspectionFailed, "artifact walker reports inspection errors instead of treating them as clean");
+
+		const std::filesystem::path protectedPath = root / "protected.cpp";
+		Saver protectedSaver(protectedPath, {"value"}, 1, true, output, error);
+		expect(!protectedSaver.save({{std::string("blocked")}}) && !std::filesystem::exists(protectedPath), "Saver rejects protected output extensions");
+
+		const std::filesystem::path directoryTarget = root / "directory.csv";
+		std::filesystem::create_directories(directoryTarget);
+		Saver directorySaver(directoryTarget, {"value"}, 1, true, output, error);
+		expect(!directorySaver.save({{std::string("blocked")}}) && std::filesystem::is_directory(directoryTarget), "Saver rejects existing non-regular targets");
+
+		const std::filesystem::path symlinkDestination = root / "symlink-destination.csv";
+		{
+			std::ofstream destination(symlinkDestination);
+			destination << "destination\n";
+		}
+		const std::filesystem::path symlinkPath = root / "symlink.csv";
+		std::error_code symlinkError;
+		std::filesystem::create_symlink(symlinkDestination, symlinkPath, symlinkError);
+		if (!symlinkError)
+		{
+			Saver symlinkSaver(symlinkPath, {"value"}, 1, true, output, error);
+			expect(!symlinkSaver.save({{std::string("blocked")}}), "Saver rejects a symlink target");
+			expect(readFile(symlinkDestination) == "destination\n", "symlink rejection preserves its destination");
+			expect(!hasSaverTemporaryArtifact(root), "symlink rejection leaves no temporary artifact");
+		}
+	}
+
+	void testFinishExecutionDoesNotBlock()
+	{
+		const auto start = std::chrono::steady_clock::now();
+		expect(finishExecution(0.0, 3, 7) == 7, "zero waiting time returns the exit code");
+		std::istringstream pipedInput("not consumed\n");
+		std::ostringstream noninteractiveOutput;
+		expect(finishExecution(std::numeric_limits<double>::infinity(), 3, 8, false, pipedInput, noninteractiveOutput) == 8, "infinity is non-blocking in a noninteractive test");
+		expect(pipedInput.peek() == 'n' && noninteractiveOutput.str().empty(), "noninteractive infinity neither reads nor prompts");
+		const auto elapsed = std::chrono::steady_clock::now() - start;
+		expect(elapsed < std::chrono::seconds(2), "zero and noninteractive infinity return promptly");
+
+		std::istringstream enter("\n");
+		std::ostringstream interactiveOutput;
+		expect(finishExecution(std::numeric_limits<double>::infinity(), 3, 9, true, enter, interactiveOutput) == 9, "interactive infinity returns after Enter");
+		expect(interactiveOutput.str().find("Press Enter") != std::string::npos && enter.peek() == std::char_traits<char>::eof(), "interactive infinity prompts and consumes Enter");
+
+		std::ostringstream countdownOutput;
+		const auto countdownStart = std::chrono::steady_clock::now();
+		expect(finishExecution(0.02, 3, 10, false, pipedInput, countdownOutput) == 10, "finite positive waiting time returns the exit code");
+		const auto countdownElapsed = std::chrono::steady_clock::now() - countdownStart;
+		expect(countdownElapsed >= std::chrono::milliseconds(10), "finite positive waiting time actually waits");
+		expect(countdownOutput.str().find("Please wait") != std::string::npos && countdownOutput.str().find("automatic exit") != std::string::npos, "finite positive waiting time reports the countdown");
+	}
+
+	void testScopedOutputSilencer()
+	{
+		std::ostringstream output;
+		output << "before";
+		{
+			ScopedOutputSilencer silencer(output, true);
+			output << "hidden";
+		}
+		output << "after";
+		expect(output.str() == "beforeafter", "enabled output silencer hides scoped output and restores the stream");
+
+		std::ostringstream visibleOutput;
+		{
+			ScopedOutputSilencer silencer(visibleOutput, false);
+			visibleOutput << "visible";
+		}
+		expect(visibleOutput.str() == "visible", "disabled output silencer leaves output visible");
+
+		std::ostringstream largeOutput;
+		{
+			ScopedOutputSilencer silencer(largeOutput, true);
+			largeOutput << std::string(4U * 1024U * 1024U, 'x');
+		}
+		expect(largeOutput.str().empty(), "large suppressed output is discarded instead of retained");
+
+		std::ostringstream unwoundOutput;
+		unwoundOutput << "before";
+		try
+		{
+			ScopedOutputSilencer silencer(unwoundOutput, true);
+			unwoundOutput << "hidden";
+			throw std::runtime_error("test unwind");
+		}
+		catch (const std::runtime_error &)
+		{
+		}
+		unwoundOutput << "after";
+		expect(unwoundOutput.str() == "beforeafter", "output silencer restores the stream during exception unwinding");
+	}
+
+	void testLegacyRandomShufflePreservesPermutation()
+	{
+		std::vector<int> values = {5, 1, 5, 2, 9, 2, 7};
+		std::vector<int> expected = values;
+		std::srand(12345);
+		legacyRandomShuffle(values.begin(), values.end());
+		std::sort(values.begin(), values.end());
+		std::sort(expected.begin(), expected.end());
+		expect(values == expected, "legacy random shuffle preserves every permutation element");
+	}
+}
+
+int main()
+{
+	const TemporaryDirectory temporaryDirectory;
+	const std::filesystem::path &root = temporaryDirectory.path();
+
+	testParserDefaultsAndAliases(root);
+	testParserPathsAndValidation(root);
+	testExecutablePathResolution(root);
+	testSaver(root);
+	testFinishExecutionDoesNotBlock();
+	testScopedOutputSilencer();
+	testLegacyRandomShufflePreservesPermutation();
+
+	if (failures != 0)
+	{
+		std::cerr << failures << " test(s) failed.\n";
+		return 1;
+	}
+	std::cout << "PASS: ParserSaver C++ tests.\n";
+	return 0;
+}

--- a/tests/cpp/runCPPRegressionTest.sh
+++ b/tests/cpp/runCPPRegressionTest.sh
@@ -48,6 +48,14 @@ done < <(find "$psi_ca_dir" -mindepth 1 ! -type d -print0)
 
 printf 'PASS: PSI-CA contains exactly the seven expected C++ source files.\n'
 
+for filename in "${expected_files[@]}"; do
+  source_path="$psi_ca_dir/$filename"
+  if grep -Eq '(^|[^[:alnum:]_])(memset|strlen)[[:space:]]*\(' "$source_path" && ! grep -Fxq '#include <cstring>' "$source_path"; then
+    printf 'Missing explicit <cstring> include for C string functions: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+done
+
 parser_saver_header="$psi_ca_dir/ParserSaver.hpp"
 if grep -Fq 'remove_all' "$parser_saver_header"; then
   printf 'ParserSaver.hpp must not recursively delete temporary paths.\n' >&2

--- a/tests/cpp/runCPPRegressionTest.sh
+++ b/tests/cpp/runCPPRegressionTest.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+psi_ca_dir="$repo_root/PSI-CA"
+expected_files=(
+  "OPSI-CA.cpp"
+  "PSI-CA.cpp"
+  "SPSI-CA(1).cpp"
+  "VPSI-CA-Alg2.cpp"
+  "VPSI-CA-Alg3.cpp"
+  "VPSI-CA-Alg4.cpp"
+  "VPSI-CA-Alg5.cpp"
+)
+vpsi_files=(
+  "VPSI-CA-Alg2.cpp"
+  "VPSI-CA-Alg3.cpp"
+  "VPSI-CA-Alg4.cpp"
+  "VPSI-CA-Alg5.cpp"
+)
+
+for filename in "${expected_files[@]}"; do
+  if [[ ! -f "$psi_ca_dir/$filename" || -L "$psi_ca_dir/$filename" ]]; then
+    printf 'Missing: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+done
+
+while IFS= read -r -d '' path; do
+  filename="${path#"$psi_ca_dir"/}"
+  if [[ "$filename" == "ParserSaver.hpp" ]]; then
+    continue
+  fi
+  is_expected=false
+  for expected_filename in "${expected_files[@]}"; do
+    if [[ "$filename" == "$expected_filename" ]]; then
+      is_expected=true
+      break
+    fi
+  done
+
+  if [[ "$is_expected" == false ]]; then
+    printf 'Unexpected: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+done < <(find "$psi_ca_dir" -mindepth 1 ! -type d -print0)
+
+printf 'PASS: PSI-CA contains exactly the seven expected C++ source files.\n'
+
+parser_saver_header="$psi_ca_dir/ParserSaver.hpp"
+if grep -Fq 'remove_all' "$parser_saver_header"; then
+  printf 'ParserSaver.hpp must not recursively delete temporary paths.\n' >&2
+  exit 1
+fi
+for required_api in mkdirat openat fstatat linkat renameat unlinkat; do
+  if ! grep -Fq "$required_api" "$parser_saver_header"; then
+    printf 'ParserSaver.hpp is missing required POSIX FD API: %s\n' "$required_api" >&2
+    exit 1
+  fi
+done
+
+for filename in "${vpsi_files[@]}"; do
+  source_path="$psi_ca_dir/$filename"
+  if grep -Fq '>> 2' "$source_path"; then
+    printf 'Incorrect VPSI aggregate space conversion remains: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  if ! grep -Eq 'double[[:space:]]+spaceKilobytes[[:space:]]*=[[:space:]]*0\.0' "$source_path"; then
+    printf 'VPSI aggregate space must retain fractional kilobytes: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  if ! grep -Eq 'spaceKilobytes[[:space:]]*=.*[/][[:space:]]*1024\.0' "$source_path"; then
+    printf 'VPSI aggregate space must divide bytes by 1024.0: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+done
+
+readme_path="$repo_root/README.md"
+if [[ ! -f "$readme_path" ]]; then
+	printf 'Missing: README.md\n' >&2
+	exit 1
+fi
+
+ruby - "$readme_path" <<'RUBY'
+def assert(condition, message)
+  raise message unless condition
+end
+
+def assert_match(text, pattern, message)
+  assert(text.match?(pattern), message)
+end
+
+readme_path = ARGV.fetch(0)
+source = File.read(readme_path)
+cpp_section = source[/^## 3\. C\+\+$.*?(?=^## 4\. Acknowledgment$)/m]
+assert(cpp_section, "README C++ section must precede Acknowledgment")
+
+inventory = source.split(/^Most of the cryptographic schemes here/, 2).first
+expected_cpp_links = [
+  "./PSI-CA/OPSI-CA.cpp",
+  "./PSI-CA/PSI-CA.cpp",
+  "./PSI-CA/SPSI-CA(1).cpp",
+  "./PSI-CA/VPSI-CA-Alg2.cpp",
+  "./PSI-CA/VPSI-CA-Alg3.cpp",
+  "./PSI-CA/VPSI-CA-Alg4.cpp",
+  "./PSI-CA/VPSI-CA-Alg5.cpp"
+]
+assert(inventory.include?("- [PSI-CA](./PSI-CA/)"), "README inventory must include the PSI-CA directory")
+actual_cpp_links = inventory.scan(/\]\((\.\/PSI-CA\/.*\.cpp)\)$/).flatten
+assert(actual_cpp_links == expected_cpp_links, "README inventory must list exactly the seven PSI-CA C++ programs")
+
+assert_match(cpp_section, /algorithms.*formatting.*C\+\+17 standard library/i, "README must describe the standard-library algorithm and formatting dependency")
+assert_match(cpp_section, /no third-party libraries/i, "README must state that the PSI-CA programs use no third-party libraries")
+assert_match(cpp_section, /file-publication path.*Ubuntu\/POSIX APIs/i, "README must identify the POSIX file-publication dependency")
+assert_match(cpp_section, /target Ubuntu\/POSIX.*compilation on Windows.*rejected/i, "README must document the supported platform and Windows rejection")
+assert(!cpp_section.include?("only the C++ standard library"), "README must not hide the POSIX API dependency")
+assert_match(cpp_section, /do not require PBC/i, "README must distinguish the PSI-CA programs from PBC-dependent C/C++")
+assert(cpp_section.include?('g++ -std=c++17 -Wall -Wextra -Wpedantic "PSI-CA/SPSI-CA(1).cpp" -o "PSI-CA/SPSI-CA(1)"'), "README must retain the quoted C++17 compile command")
+assert(cpp_section.include?('-o "results.csv" -p 9 -r 10 -t 0 -y'), "README must retain the noninteractive run command")
+
+assert_match(cpp_section, /Only UTF-8.*accepted/i, "README must document the UTF-8-only input encoding")
+assert_match(cpp_section, /default output.*``<program>\.csv``/i, "README must document the default CSV output name")
+assert_match(cpp_section, /default decimal place.*9/i, "README must document decimal place 9")
+assert_match(cpp_section, /default run count.*10/i, "README must document run count 10")
+assert_match(cpp_section, /default waiting time.*infinity/i, "README must document the non-blocking infinite default")
+assert_match(cpp_section, /relative output path.*executable's directory/i, "README must document the executable-relative output base")
+assert_match(cpp_section, /directory path.*default.*``<program>\.csv``/i, "README must document output directory handling")
+assert_match(cpp_section, /protected source or script extension.*reset.*``\.csv``/i, "README must document parser protection for extensions")
+assert_match(cpp_section, /saver.*rejects a protected extension/i, "README must document saver protection for extensions")
+assert_match(cpp_section, /existing output.*``-y``.*interactive confirmation/i, "README must document overwrite authorization")
+assert_match(cpp_section, /private.*workspace/i, "README must document the private output workspace")
+%w[mkdirat openat linkat renameat unlinkat].each do |api|
+  assert(cpp_section.include?("``#{api}``"), "README must document directory-FD API #{api}")
+end
+assert_match(cpp_section, /directory-FD-anchored/i, "README must describe descriptor-anchored publication operations")
+assert_match(cpp_section, /``linkat``.*no-clobber/i, "README must document no-clobber publication")
+assert_match(cpp_section, /``renameat``.*authorized replacement/i, "README must document authorized replacement")
+assert_match(cpp_section, /not crash-durable/i, "README must not imply crash durability")
+assert_match(cpp_section, /does not call ``fsync``/i, "README must explain the crash-durability limit")
+assert_match(cpp_section, /rejects.*symlink.*non-regular target/i, "README must document unsafe target rejection")
+assert_match(cpp_section, /not a general security guarantee/i, "README must avoid overstating the publication mechanism")
+assert_match(cpp_section, /CSV, TSV, and TXT.*default/i, "README must document supported formats and the default")
+assert_match(cpp_section, /unsupported extension.*TXT.*fallback/i, "README must document TXT fallback")
+assert_match(cpp_section, /integers are written without decimal places/, "README must document integer formatting with sentence-internal lowercase")
+assert(!cpp_section.include?("Integers are written"), "README must not capitalize sentence-internal integers")
+
+assert_match(cpp_section, /``EXIT_SUCCESS``.*\(\$0\$\).*result is saved/i, "README must document successful save exit 0")
+assert_match(cpp_section, /``EXIT_FAILURE``.*\(\$1\$\).*saving fails/i, "README must document save failure exit 1")
+assert_match(cpp_section, /invalid arguments.*``-1``.*255.*POSIX/i, "README must document literal -1 and POSIX status 255")
+assert(!cpp_section.match?(/\bEOF\b/), "README must not call the invalid-argument return value EOF")
+assert_match(cpp_section, /Help exits.*\(\$0\$\)/i, "README must document help exit 0")
+assert_match(cpp_section, /do not expose a separate correctness boolean/i, "README must not tie exit status to an unavailable correctness result")
+
+{
+  "encoding" => %w[e /e -e encoding /encoding --encoding],
+  "help" => %w[h /h -h help /help --help],
+  "output" => %w[o /o -o output /output --output],
+  "place" => %w[p /p -p place /place --place],
+  "quiet" => %w[q /q -q quiet /quiet --quiet],
+  "run" => %w[r /r -r run /run --run],
+  "time" => %w[t /t -t time /time --time],
+  "yes" => %w[y /y -y yes /yes --yes]
+}.each do |name, aliases|
+  aliases.each do |alias_name|
+    assert(cpp_section.match?(/`#{Regexp.escape(alias_name)}`/), "README must document the #{name} alias #{alias_name}")
+  end
+end
+assert_match(cpp_section, /aliases.*case-insensitive/i, "README must state that C++ option aliases are case-insensitive")
+
+assert(cpp_section.include?("[``runCPP`` workflow](./.github/workflows/runCPP.yml)"), "README must link the runCPP workflow")
+assert_match(cpp_section, /seven-program matrix.*``ubuntu-latest``/i, "README must document the workflow matrix and Ubuntu runner")
+assert_match(cpp_section, /actions.*pinned.*commit SHAs/i, "README must document pinned actions")
+assert(cpp_section.include?("``-std=c++17 -Wall -Wextra -Wpedantic``"), "README must document the workflow compiler flags")
+assert_match(cpp_section, /help command.*real execution/i, "README must document both workflow executions")
+assert_match(cpp_section, /uploaded as artifacts/i, "README must document artifact upload")
+assert_match(cpp_section, /Manual dispatch.*output format.*decimal place.*run count/i, "README must document the manual inputs")
+assert_match(cpp_section, /run count.*1 through 100.*falls back to 10/i, "README must document the manual run cap and fallback")
+assert_match(cpp_section, /30-minute timeout/i, "README must document the workflow timeout")
+
+assert_match(cpp_section, /^### 3\.2 Time complexity$/m, "README must include the C++ time subsection")
+assert_match(cpp_section, /``clock\(\)``.*``CLOCKS_PER_SEC``.*milliseconds/im, "README must document CPU-clock conversion to milliseconds")
+assert_match(cpp_section, /per-run average/i, "README must document time averaging")
+assert_match(cpp_section, /``baseNum``.*VPSI.*``adjust``/im, "README must document retained baseNum and VPSI adjustments")
+assert_match(cpp_section, /OPSI.*SPSI.*actor-specific modeled costs/im, "README must document retained modeled actor costs")
+
+assert_match(cpp_section, /^### 3\.3 Space complexity$/m, "README must include the C++ space subsection")
+assert_match(cpp_section, /academic formulas.*``printSize``/i, "README must identify printSize academic estimates")
+assert_match(cpp_section, /OPSI-CA.*PSI-CA.*SPSI-CA.*report bytes/i, "README must document byte units for OPSI, PSI, and SPSI")
+assert_match(cpp_section, /VPSI.*aggregate byte totals.*1024\.0.*kilobytes/i, "README must document correct VPSI byte-to-kilobyte conversion")
+assert_match(cpp_section, /serialized or object-model estimates.*not.*process RSS/im, "README must distinguish estimates from process RSS")
+assert_match(cpp_section, /external memory monitor.*peak memory/i, "README must direct peak-memory measurement externally")
+
+dependency_table = source[/\| Programming language \| Dependency \|.*?(?=\n\n)/m]
+assert(dependency_table, "README must retain the dependency summary table")
+assert(dependency_table.include?("C++ (PSI-CA)"), "README dependency table must distinguish the standalone PSI-CA C++ programs")
+assert(dependency_table.include?("C (and pairing-based C/C++)"), "README dependency table must retain the PBC pairing dependency separately")
+assert_match(dependency_table, /C\+\+17 standard library.*Ubuntu\/POSIX APIs.*no third-party libraries/i, "README dependency table must state both PSI-CA platform dependencies")
+assert_match(dependency_table, /Windows compilation.*rejected/i, "README dependency table must document Windows rejection")
+RUBY
+
+printf 'PASS: README documents the seven C++ programs, their CLI, workflow, and measurements.\n'
+
+workflow_path="$repo_root/.github/workflows/runCPP.yml"
+if [[ ! -f "$workflow_path" ]]; then
+  printf 'Missing: .github/workflows/runCPP.yml\n' >&2
+  exit 1
+fi
+
+ruby - "$workflow_path" <<'RUBY'
+require "json"
+require "open3"
+require "tmpdir"
+require "yaml"
+
+def assert(condition, message)
+  raise message unless condition
+end
+
+def execute_output(step, environment, output_name)
+  Dir.mktmpdir("runCPP-step") do |directory|
+    output_path = File.join(directory, "github-output")
+    command_environment = { "GITHUB_OUTPUT" => output_path }.merge(environment)
+    stdout, stderr, status = Open3.capture3(command_environment, "bash", "-c", step.fetch("run"))
+    assert(status.success?, "#{step.fetch("name")} failed for #{environment.inspect}: #{stdout}#{stderr}")
+    outputs = File.readlines(output_path, chomp: true).to_h { |line| line.split("=", 2) }
+    outputs.fetch(output_name)
+  end
+end
+
+workflow_path = ARGV.fetch(0)
+workflow_source = File.read(workflow_path)
+workflow = YAML.load_file(workflow_path)
+assert(workflow.is_a?(Hash), "runCPP.yml must contain a YAML mapping")
+assert(workflow["name"] == "Run C++", "runCPP.yml must be named Run C++")
+
+triggers = workflow["on"] || workflow[true]
+assert(triggers.is_a?(Hash), "runCPP.yml must define workflow triggers")
+expected_paths = ["PSI-CA/**/*.cpp", "PSI-CA/**/*.hpp", ".github/workflows/runCPP.yml"]
+["pull_request", "push"].each do |event|
+  config = triggers[event]
+  assert(config.is_a?(Hash), "runCPP.yml must define #{event}")
+  assert(config["branches"] == ["main"], "#{event} must target main")
+  assert(config["paths"] == expected_paths, "#{event} must filter C++ sources, headers, and runCPP.yml")
+end
+
+dispatch = triggers["workflow_dispatch"]
+assert(dispatch.is_a?(Hash), "runCPP.yml must define workflow_dispatch")
+inputs = dispatch["inputs"]
+assert(inputs.is_a?(Hash), "workflow_dispatch must define inputs")
+assert(inputs.keys.sort == ["decimalPlace", "outputFormat", "runCount"], "workflow_dispatch must expose exactly the supported inputs")
+assert(inputs.dig("outputFormat", "type") == "choice", "outputFormat must be a choice")
+assert(inputs.dig("outputFormat", "default") == ".csv", "outputFormat must default to .csv")
+assert(inputs.dig("outputFormat", "options") == [".csv", ".tsv", ".txt"], "outputFormat choices must be the C++ formats")
+expected_decimal_places = %w[0 s second 3 ms millisecond 6 microsecond 9 ns nanosecond 12 ps picosecond 15 fs femtosecond 18]
+assert(inputs.dig("decimalPlace", "type") == "choice", "decimalPlace must be a choice")
+assert(inputs.dig("decimalPlace", "default").to_s == "9", "decimalPlace must default to 9")
+assert(inputs.dig("decimalPlace", "options").map(&:to_s) == expected_decimal_places, "decimalPlace choices are incomplete")
+assert(inputs.dig("runCount", "type") == "string", "runCount must be a string")
+assert(inputs.dig("runCount", "default") == "10", "runCount must default to 10")
+assert(inputs.dig("runCount", "description").to_s.include?("1-100"), "runCount must document its CI range")
+
+jobs = workflow["jobs"]
+prepare = jobs && jobs["prepare"]
+run_cpp = jobs && jobs["runCPP"]
+assert(prepare.is_a?(Hash) && run_cpp.is_a?(Hash), "runCPP.yml must define prepare and runCPP jobs")
+assert(prepare["runs-on"] == "ubuntu-latest", "prepare must run on ubuntu-latest")
+assert(run_cpp["runs-on"] == "ubuntu-latest", "runCPP must run on ubuntu-latest")
+assert(run_cpp["timeout-minutes"] == 30, "runCPP must time out after 30 minutes")
+assert(run_cpp.dig("strategy", "fail-fast") == false, "runCPP matrix must not fail fast")
+
+expected_sources = [
+  "PSI-CA/OPSI-CA.cpp",
+  "PSI-CA/PSI-CA.cpp",
+  "PSI-CA/SPSI-CA(1).cpp",
+  "PSI-CA/VPSI-CA-Alg2.cpp",
+  "PSI-CA/VPSI-CA-Alg3.cpp",
+  "PSI-CA/VPSI-CA-Alg4.cpp",
+  "PSI-CA/VPSI-CA-Alg5.cpp"
+]
+prepare_steps = prepare["steps"] || []
+matrix_step = prepare_steps.find { |step| step["id"] == "matrix" }
+assert(matrix_step, "prepare must expose a matrix step")
+matrix_json = matrix_step["run"].to_s[/matrix='([^']+)'/, 1]
+assert(matrix_json, "matrix step must prepare an exact JSON array")
+assert(JSON.parse(matrix_json) == expected_sources, "matrix must contain exactly the seven C++ sources")
+assert(prepare.dig("outputs", "matrix") == "${{ steps.matrix.outputs.matrix }}", "prepare must expose the matrix")
+assert(prepare.dig("outputs", "decimalPlace") == "${{ steps.decimalPlace.outputs.decimalPlace }}", "prepare must expose decimalPlace")
+assert(prepare.dig("outputs", "runCount") == "${{ steps.runCount.outputs.runCount }}", "prepare must expose runCount")
+assert(prepare.dig("outputs", "timeString") == "${{ steps.timeString.outputs.timeString }}", "prepare must expose timeString")
+
+decimal_step = prepare_steps.find { |step| step["id"] == "decimalPlace" }
+run_count_step = prepare_steps.find { |step| step["id"] == "runCount" }
+time_step = prepare_steps.find { |step| step["id"] == "timeString" }
+assert(decimal_step && decimal_step["run"].to_s.include?("femtosecond"), "prepare must translate decimal-place aliases")
+assert(decimal_step["run"].to_s.include?("decimalPlace=18"), "prepare must support decimal place 18")
+assert(run_count_step && run_count_step["run"].to_s.include?("runCount=10"), "prepare must safely default invalid run counts")
+assert(time_step && time_step.dig("env", "TZ") == "Asia/Hong_Kong", "prepare must use Hong Kong time")
+assert(time_step["run"].to_s.include?("HKT"), "timeString must use the HKT prefix")
+
+{
+  "0" => "10",
+  "000" => "10",
+  "001" => "1",
+  "100" => "100",
+  "101" => "10",
+  "-1" => "10",
+  "junk" => "10",
+  "999999999999999999999999999999" => "10"
+}.each do |input, expected|
+  actual = execute_output(run_count_step, { "runCountString" => input }, "runCount")
+  assert(actual == expected, "runCount #{input.inspect} must normalize to #{expected}, got #{actual}")
+end
+
+{
+  "0" => "0", "s" => "0", "second" => "0",
+  "3" => "3", "ms" => "3", "millisecond" => "3",
+  "6" => "6", "microsecond" => "6",
+  "9" => "9", "ns" => "9", "nanosecond" => "9",
+  "12" => "12", "ps" => "12", "picosecond" => "12",
+  "15" => "15", "fs" => "15", "femtosecond" => "15",
+  "18" => "18", "invalid" => "9"
+}.each do |input, expected|
+  actual = execute_output(decimal_step, { "decimalPlaceString" => input }, "decimalPlace")
+  assert(actual == expected, "decimalPlace #{input.inspect} must normalize to #{expected}, got #{actual}")
+end
+
+multiline_steps = jobs.values.flat_map { |job| job["steps"] || [] }.select { |step| step["run"].is_a?(String) }
+assert(multiline_steps.all? { |step| step["run"].start_with?("set -euo pipefail\n") }, "every multiline run block must enable strict shell mode")
+
+run_steps = run_cpp["steps"] || []
+checkout_sha = "d23441a48e516b6c34aea4fa41551a30e30af803"
+upload_sha = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+checkout = run_steps.find { |step| step["uses"] == "actions/checkout@#{checkout_sha}" }
+assert(checkout && checkout.dig("with", "sparse-checkout").to_s.lines.map(&:strip).include?("PSI-CA/"), "runCPP must sparse-checkout PSI-CA")
+assert(checkout.dig("with", "persist-credentials") == false, "checkout must not persist credentials")
+assert(workflow_source.include?("uses: actions/checkout@#{checkout_sha} # v6"), "checkout SHA must retain its v6 comment")
+ready = run_steps.find { |step| step["id"] == "ready" }
+assert(ready, "runCPP must derive safe source and output paths")
+ready_script = ready["run"].to_s
+assert(ready_script.include?('sourcePath="${{ github.workspace }}/${{ matrix.cryptographicScheme }}"'), "sourcePath must be rooted in the workspace")
+assert(ready_script.include?('outputFilePath="${directoryPath}/${mainFileName}-C++'), "output path must remain beside the source")
+
+compile_step = run_steps.find { |step| step["name"] == "Compile the cryptographic scheme" }
+assert(compile_step, "runCPP must compile every matrix source")
+compile_command = 'g++ -std=c++17 -Wall -Wextra -Wpedantic "${sourcePath}" -o "${binaryPath}"'
+assert(compile_step["run"].to_s.include?(compile_command), "compile command must use C++17 and all warning flags")
+
+execute_step = run_steps.find { |step| step["name"] == "Run the cryptographic scheme" }
+assert(execute_step, "runCPP must execute every compiled binary")
+execute_script = execute_step["run"].to_s
+assert(execute_script.include?('"${binaryPath}" -t 0 -h'), "runCPP must execute the help command")
+actual_command = '"${binaryPath}" -o "${outputFileName}" -p "${decimalPlace}" -r "${runCount}" -t 0 -y'
+assert(execute_script.include?(actual_command), "runCPP must execute the real command with all required options")
+
+upload = run_steps.find { |step| step["uses"] == "actions/upload-artifact@#{upload_sha}" }
+assert(upload, "runCPP must upload the result with the approved upload-artifact SHA")
+assert(workflow_source.include?("uses: actions/upload-artifact@#{upload_sha} # v7"), "upload-artifact SHA must retain its v7 comment")
+assert(upload.dig("with", "path") == "${{ github.workspace }}/${{ steps.ready.outputs.outputFilePath }}", "artifact path must point to the generated PSI-CA result")
+assert(upload.dig("with", "archive") == false, "artifact upload must disable archiving")
+assert(upload.dig("with", "if-no-files-found") == "error", "artifact upload must fail when output is absent")
+RUBY
+
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint "$workflow_path" >/dev/null
+fi
+
+printf 'PASS: runCPP workflow covers all seven programs with strict compiler warnings and artifact checks.\n'
+
+test_directory="$(mktemp -d "${TMPDIR:-/tmp}/PSI-CA-CPP.XXXXXX")"
+trap 'rm -rf "$test_directory"' EXIT
+test_binary="$test_directory/ParserSaverTest"
+"${CXX:-g++}" -std=c++17 -Wall -Wextra -Wpedantic "$repo_root/tests/cpp/ParserSaverTest.cpp" -o "$test_binary"
+"$test_binary"
+
+for filename in "${expected_files[@]}"; do
+  source_path="$psi_ca_dir/$filename"
+  basename="${filename%.cpp}"
+  binary_path="$test_directory/$basename"
+  output_path="$test_directory/$basename.csv"
+
+  if ! grep -Fq '#include "ParserSaver.hpp"' "$source_path"; then
+    printf 'Missing ParserSaver.hpp integration: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  if ! grep -Eq 'int[[:space:]]+main[[:space:]]*\([[:space:]]*int[[:space:]]+argc[[:space:]]*,[[:space:]]*char[[:space:]]*\*[[:space:]]*argv[[:space:]]*\[[[:space:]]*\][[:space:]]*\)' "$source_path"; then
+    printf 'Missing command-line main signature: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  if ! grep -Eq 'Parser[[:space:]]+[[:alnum:]_]+' "$source_path"; then
+    printf 'Missing Parser construction: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  if ! grep -Eq 'Saver[[:space:]]+[[:alnum:]_]+' "$source_path"; then
+    printf 'Missing Saver construction: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  if ! grep -Fq 'options.runCount' "$source_path"; then
+    printf 'Missing run-count integration: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  if grep -Eq '(^|[^[:alnum:]_])dump[[:space:]]*\(' "$source_path"; then
+    printf 'Legacy dump function remains: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+
+  "${CXX:-g++}" -std=c++17 -Wall -Wextra -Wpedantic "$source_path" -o "$binary_path"
+  "$binary_path" -h -t 0 >"$test_directory/$basename-help.stdout" 2>"$test_directory/$basename-help.stderr"
+  "$binary_path" -q -r 2 -t 0 -y -o "$output_path" >"$test_directory/$basename-run.stdout" 2>"$test_directory/$basename-run.stderr"
+
+  path_run_directory="$test_directory/$basename-path-cwd"
+  path_output_name="$basename-path.csv"
+  path_output="$test_directory/$path_output_name"
+  mkdir -p "$path_run_directory"
+  (
+    cd "$path_run_directory"
+    PATH="$test_directory:${PATH:-}" "$basename" -q -r 1 -t 0 -y -o "$path_output_name"
+  ) >"$test_directory/$basename-path.stdout" 2>"$test_directory/$basename-path.stderr"
+  if [[ ! -s "$path_output" ]]; then
+    printf 'Bare PATH launch did not save beside its binary: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  if [[ -e "$path_run_directory/$path_output_name" ]]; then
+    printf 'Bare PATH launch incorrectly saved relative to cwd: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+
+  if [[ ! -s "$output_path" ]]; then
+    printf 'Missing or empty saved output: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  header="$(head -n 1 "$output_path")"
+  if [[ "$header" != *scheme* || "$header" != *runCount* ]]; then
+    printf 'Saved header lacks scheme/runCount: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+  if [[ "$(wc -l < "$output_path")" -lt 2 ]]; then
+    printf 'Saved output lacks a data row: PSI-CA/%s\n' "$filename" >&2
+    exit 1
+  fi
+
+  python3 - "$output_path" <<'PY'
+import csv
+import math
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+with path.open(newline="", encoding="utf-8") as stream:
+    rows = list(csv.reader(stream))
+
+if len(rows) != 2:
+    raise SystemExit(f"{path}: expected exactly one header and one data row, got {len(rows)} rows")
+header, data = rows
+if len(header) != len(data):
+    raise SystemExit(f"{path}: header has {len(header)} fields but data has {len(data)}")
+record = dict(zip(header, data))
+if record.get("runCount") != "2":
+    raise SystemExit(f"{path}: expected saved runCount 2, got {record.get('runCount')!r}")
+
+scheme = record.get("scheme")
+if scheme and scheme.startswith("VPSI-CA-"):
+    space_kilobytes = float(record["spaceKilobytes"])
+    if not math.isfinite(space_kilobytes) or space_kilobytes <= 0.0:
+        raise SystemExit(f"{path}: expected a positive finite VPSI spaceKilobytes value")
+if scheme == "OPSI-CA":
+    sender_overhead = ((1 << 22) - (1 << 10)) / math.pow(math.e, 3) / math.log(6)
+    if float(record["senderCpuMilliseconds"]) < sender_overhead:
+        raise SystemExit(f"{path}: OPSI sender modeled overhead is missing")
+    if float(record["cloudCpuMilliseconds"]) < 10.0:
+        raise SystemExit(f"{path}: OPSI cloud modeled overhead is missing")
+elif scheme == "SPSI-CA":
+    sender_overhead = ((1 << 24) - (1 << 12)) / math.pow(math.e, 3) / math.log(6)
+    if float(record["senderCpuMilliseconds"]) < sender_overhead:
+        raise SystemExit(f"{path}: SPSI sender modeled overhead is missing")
+    if float(record["cloudCpuMilliseconds"]) < 36.0:
+        raise SystemExit(f"{path}: SPSI cloud modeled overhead is missing")
+PY
+done
+
+printf 'PASS: all seven C++ programs compile, accept CLI options, and save a summary row.\n'


### PR DESCRIPTION
## Summary

- add the seven PSI-CA C++ implementations under `PSI-CA/`
- add a shared command-line `Parser` and CSV/TSV/TXT `Saver`
- add `.github/workflows/runCPP.yml` to compile every source with `g++ -Wall -Wextra -Wpedantic` and execute the resulting binaries
- add C++ usage, dependency, measurement, and workflow documentation to `README.md`

## Why

The repository already provides consistent Python and Java execution paths. This change gives the seven supplied PSI-CA C++ programs equivalent command-line handling, result storage, documentation, and CI coverage.

## Implementation notes

- relative output paths are resolved from the executable directory, including bare commands located through `PATH`
- result storage has no third-party dependency and supports CSV, TSV, and TXT
- Ubuntu/POSIX publication uses private workspaces and directory-FD-anchored `mkdirat`, `openat`, `linkat`, `renameat`, and `unlinkat` operations
- unapproved replacement is atomic and no-clobber; approved replacement is atomic through `renameat`
- the seven legacy algorithms are preserved while their run count, timing, and result-saving paths are integrated

## Validation

- `tests/cpp/runCPPRegressionTest.sh` passes all five checks
- all seven programs compile with C++17, `-Wall`, `-Wextra`, and `-Wpedantic`
- all seven binaries execute, accept the shared CLI, save a summary row, and pass bare-`PATH` output-path checks
- focused `ParserSaverTest.cpp` compiles without warnings and passes
- workflow YAML parsing, shell syntax checks, `actionlint`, and `git diff --check` pass

The compiler still reports warnings inherited from the supplied legacy algorithm sources; no new Parser/Saver warning remains.
