### PR TITLE
Avoid potential zero-division errors

### DIFF
--- a/SchemeCANIFPPCT/SchemeCANIFPPCT.java
+++ b/SchemeCANIFPPCT/SchemeCANIFPPCT.java
@@ -971,12 +971,12 @@ public final class SchemeCANIFPPCT
 		return this.immutable(this.pairing.getZr().newRandomElement());
 	}
 
-	private Element randomNonZeroScalar()
+	private Element generateRandomNonZeroZRElement()
 	{
-		Element scalar = this.randomScalar();
-		while (scalar.isZero())
-			scalar = this.randomScalar();
-		return scalar;
+		Element element = this.randomScalar();
+		while (element.isZero())
+			element = this.randomScalar();
+		return element;
 	}
 
 	private Element randomG1()
@@ -1252,10 +1252,10 @@ public final class SchemeCANIFPPCT
 		}
 		final Element g = this.randomG1();
 		final Element omega = this.randomScalar();
-		final Element t1 = this.randomNonZeroScalar();
-		final Element t2 = this.randomNonZeroScalar();
-		final Element t3 = this.randomNonZeroScalar();
-		final Element t4 = this.randomNonZeroScalar();
+		final Element t1 = this.generateRandomNonZeroZRElement();
+		final Element t2 = this.generateRandomNonZeroZRElement();
+		final Element t3 = this.generateRandomNonZeroZRElement();
+		final Element t4 = this.generateRandomNonZeroZRElement();
 		final Element omegaPublic = power(this.pair(g, g), scalarProduct(scalarProduct(t1, t2), omega));
 		this.basicPublicKey = new BasicPublicKey(g, this.randomG1(), omegaPublic, power(g, t1), power(g, t2), power(g, t3), power(g, t4));
 		this.basicSecretKey = new BasicSecretKey(omega, t1, t2, t3, t4);
@@ -1335,13 +1335,13 @@ public final class SchemeCANIFPPCT
 		final Element g1 = this.randomG1();
 		final Element g2 = this.randomG2();
 		final Element r = this.randomScalar();
-		final Element s = this.randomNonZeroScalar();
+		final Element s = this.generateRandomNonZeroZRElement();
 		final Element t = this.randomScalar();
 		final Element omega = this.randomScalar();
-		final Element t1 = this.randomNonZeroScalar();
-		final Element t2 = this.randomNonZeroScalar();
-		final Element t3 = this.randomNonZeroScalar();
-		final Element t4 = this.randomNonZeroScalar();
+		final Element t1 = this.generateRandomNonZeroZRElement();
+		final Element t2 = this.generateRandomNonZeroZRElement();
+		final Element t3 = this.generateRandomNonZeroZRElement();
+		final Element t4 = this.generateRandomNonZeroZRElement();
 		this.masterPublicKey = new MasterPublicKey(
 			g1, g2, this.randomG1(), power(g1, r), power(g2, s), power(g1, t),
 			power(this.pair(g1, g2), scalarProduct(scalarProduct(t1, t2), omega)),
@@ -1357,7 +1357,7 @@ public final class SchemeCANIFPPCT
 			this.Setup(this.n, this.m);
 		final List<TraceEntry> entries = tracingList == null ? new ArrayList<>() : tracingList;
 		final Element secretKey = this.randomScalar();
-		final Element x = this.randomNonZeroScalar();
+		final Element x = this.generateRandomNonZeroZRElement();
 		final Element denominator = scalarProduct(this.masterSecretKey.s(), x);
 		final Element z = scalarProduct(subtract(this.masterSecretKey.r(), x), denominator.duplicate().invert().getImmutable());
 		final Element zPublic = power(this.masterPublicKey.g1(), z);

--- a/SchemeCANIFPPCT/SchemeCANIFPPCT.py
+++ b/SchemeCANIFPPCT/SchemeCANIFPPCT.py
@@ -643,6 +643,11 @@ class SchemeCANIFPPCT:
 			return eleResult
 		else:
 			return None
+	def __generateRandomNonZeroZRElement(self:object) -> Element:
+		element = self.__group.random(ZR)
+		while element == self.__group.init(ZR, 0):
+			element = self.__group.random(ZR)
+		return element
 	def BSetup(self:object, n:int = __DefaultN, m:int = __DefaultM) -> tuple: # $\textbf{BSetup}(n, m) \to (\textit{bpk}, \textit{bsk})$
 		# Checks #
 		self.__bFlag = False
@@ -660,7 +665,8 @@ class SchemeCANIFPPCT:
 		g1 = self.__group.random(G1) # generate $g_1 \in \mathbb{G}_1$ randomly
 		H1 = lambda x: self.__group.hash(x, G1) # $H_1: \{0, 1\}^* \to \mathbb{G}_1$
 		H2 = lambda x: self.__group.hash(self.__group.serialize(x), ZR) # $H_2: \mathbb{G}_1 \to \mathbb{Z}_r$
-		omega, t1, t2, t3, t4 = self.__group.random(ZR, 5) # generate $\omega, t_1, t_2, t_3, t_4 \in \mathbb{Z}_r$ randomly
+		omega = self.__group.random(ZR) # generate $\omega \in \mathbb{Z}_r$ randomly
+		t1, t2, t3, t4 = tuple(self.__generateRandomNonZeroZRElement() for _ in range(4)) # generate $t_1, t_2, t_3, t_4 \in \mathbb{Z}_r^*$ randomly
 		Omega = pair(g, g) ** (t1 * t2 * omega) # $\Omega \gets e(g, g)^{t_1 t_2 \omega}$
 		v1 = g ** t1 # $v_1 \gets g^{t_1}$
 		v2 = g ** t2 # $v_2 \gets g^{t_2}$
@@ -816,7 +822,8 @@ class SchemeCANIFPPCT:
 		H2 = lambda x: self.__group.hash(self.__group.serialize(x), ZR) # $H_2: \mathbb{G}_T \to \mathbb{Z}_r$
 		H3 = lambda x: self.__group.hash(x, ZR) # $H_3: \{0, 1\}^* \to \mathbb{Z}_r$
 		H4 = lambda x: self.__group.hash(self.__group.serialize(x), ZR) # $H_4: \mathbb{G}_1 \to \mathbb{Z}_r$
-		r, s, t, omega, t1, t2, t3, t4 = self.__group.random(ZR, 8) # generate $r, s, t, \omega, t_1, t_2, t_3, t_4 \in \mathbb{Z}_r$ randomly
+		r, t, omega = self.__group.random(ZR, 3) # generate $r, t, \omega \in \mathbb{Z}_r$ randomly
+		s, t1, t2, t3, t4 = tuple(self.__generateRandomNonZeroZRElement() for _ in range(5)) # generate $s, t_1, t_2, t_3, t_4 \in \mathbb{Z}_r^*$ randomly
 		R = g1 ** r # $R \gets g_1^r$
 		S = g2 ** s # $S \gets g_2^s$
 		T = g1 ** t # $T \gets g_1^t$
@@ -847,7 +854,7 @@ class SchemeCANIFPPCT:
 		r, s = self.__msk[0], self.__msk[1]
 		
 		# Scheme #
-		k_i, x_i = self.__group.random(ZR), self.__group.random(ZR) # generate $k_i, x_i \in \mathbb{Z}_r$
+		k_i, x_i = self.__group.random(ZR), self.__generateRandomNonZeroZRElement() # generate $k_i \in \mathbb{Z}_r$ and $x_i \in \mathbb{Z}_r^*$
 		z_i = (r - x_i) * (s * x_i) ** (-1) # $z_i \gets \frac{r - x_i}{s x_i}$
 		Z_i = g1 ** z_i # $Z_i \gets g_1^{z_i}$
 		sk_ID_i = k_i # $\textit{sk}_{\textit{ID}_i} \gets k_i$

--- a/SchemeCANIFPPCT/SchemeCANIPSI.java
+++ b/SchemeCANIFPPCT/SchemeCANIPSI.java
@@ -971,12 +971,12 @@ public final class SchemeCANIPSI
 		return this.immutable(this.pairing.getZr().newRandomElement());
 	}
 
-	private Element randomNonZeroScalar()
+	private Element generateRandomNonZeroZRElement()
 	{
-		Element scalar = this.randomScalar();
-		while (scalar.isZero())
-			scalar = this.randomScalar();
-		return scalar;
+		Element element = this.randomScalar();
+		while (element.isZero())
+			element = this.randomScalar();
+		return element;
 	}
 
 	private Element randomG1()
@@ -1252,10 +1252,10 @@ public final class SchemeCANIPSI
 		}
 		final Element g = this.randomG1();
 		final Element omega = this.randomScalar();
-		final Element t1 = this.randomNonZeroScalar();
-		final Element t2 = this.randomNonZeroScalar();
-		final Element t3 = this.randomNonZeroScalar();
-		final Element t4 = this.randomNonZeroScalar();
+		final Element t1 = this.generateRandomNonZeroZRElement();
+		final Element t2 = this.generateRandomNonZeroZRElement();
+		final Element t3 = this.generateRandomNonZeroZRElement();
+		final Element t4 = this.generateRandomNonZeroZRElement();
 		final Element omegaPublic = power(this.pair(g, g), scalarProduct(scalarProduct(t1, t2), omega));
 		this.basicPublicKey = new BasicPublicKey(g, this.randomG1(), omegaPublic, power(g, t1), power(g, t2), power(g, t3), power(g, t4));
 		this.basicSecretKey = new BasicSecretKey(omega, t1, t2, t3, t4);
@@ -1335,13 +1335,13 @@ public final class SchemeCANIPSI
 		final Element g1 = this.randomG1();
 		final Element g2 = this.randomG2();
 		final Element r = this.randomScalar();
-		final Element s = this.randomNonZeroScalar();
+		final Element s = this.generateRandomNonZeroZRElement();
 		final Element t = this.randomScalar();
 		final Element omega = this.randomScalar();
-		final Element t1 = this.randomNonZeroScalar();
-		final Element t2 = this.randomNonZeroScalar();
-		final Element t3 = this.randomNonZeroScalar();
-		final Element t4 = this.randomNonZeroScalar();
+		final Element t1 = this.generateRandomNonZeroZRElement();
+		final Element t2 = this.generateRandomNonZeroZRElement();
+		final Element t3 = this.generateRandomNonZeroZRElement();
+		final Element t4 = this.generateRandomNonZeroZRElement();
 		this.masterPublicKey = new MasterPublicKey(
 			g1, g2, this.randomG1(), power(g1, r), power(g2, s), power(g1, t),
 			power(this.pair(g1, g2), scalarProduct(scalarProduct(t1, t2), omega)),
@@ -1357,7 +1357,7 @@ public final class SchemeCANIPSI
 			this.Setup(this.n, this.m);
 		final List<TraceEntry> entries = tracingList == null ? new ArrayList<>() : tracingList;
 		final Element secretKey = this.randomScalar();
-		final Element x = this.randomNonZeroScalar();
+		final Element x = this.generateRandomNonZeroZRElement();
 		final Element denominator = scalarProduct(this.masterSecretKey.s(), x);
 		final Element z = scalarProduct(subtract(this.masterSecretKey.r(), x), denominator.duplicate().invert().getImmutable());
 		final Element zPublic = power(this.masterPublicKey.g1(), z);

--- a/SchemeCANIFPPCT/SchemeCANIPSI.py
+++ b/SchemeCANIFPPCT/SchemeCANIPSI.py
@@ -643,6 +643,11 @@ class SchemeCANIPSI:
 			return eleResult
 		else:
 			return None
+	def __generateRandomNonZeroZRElement(self:object) -> Element:
+		element = self.__group.random(ZR)
+		while element == self.__group.init(ZR, 0):
+			element = self.__group.random(ZR)
+		return element
 	def BSetup(self:object, n:int = __DefaultN, m:int = __DefaultM) -> tuple: # $\textbf{BSetup}(n, m) \to (\textit{bpk}, \textit{bsk})$
 		# Checks #
 		self.__bFlag = False
@@ -661,7 +666,7 @@ class SchemeCANIPSI:
 		H1 = lambda x: self.__group.hash(x, G1) # $H_1: \{0, 1\}^* \to \mathbb{G}_1$
 		H2 = lambda x: self.__group.hash(self.__group.serialize(x), ZR) # $H_2: \mathbb{G}_1 \to \mathbb{Z}_r$
 		omega = self.__group.random(ZR) # generate $\omega \in \mathbb{Z}_r$ randomly
-		t1, t2, t3, t4 = self.__group.random(ZR, 4) # generate $t_1, t_2, t_3, t_4 \in \mathbb{Z}_r^*$ randomly
+		t1, t2, t3, t4 = tuple(self.__generateRandomNonZeroZRElement() for _ in range(4)) # generate $t_1, t_2, t_3, t_4 \in \mathbb{Z}_r^*$ randomly
 		Omega = pair(g, g) ** (t1 * t2 * omega) # $\Omega \gets e(g, g)^{t_1 t_2 \omega}$
 		v1 = g ** t1 # $v_1 \gets g^{t_1}$
 		v2 = g ** t2 # $v_2 \gets g^{t_2}$
@@ -802,7 +807,7 @@ class SchemeCANIPSI:
 		H3 = lambda x: self.__group.hash(x, ZR) # $H_3: \{0, 1\}^* \to \mathbb{Z}_r$
 		H4 = lambda x: self.__group.hash(self.__group.serialize(x), ZR) # $H_4: \mathbb{G}_1 \to \mathbb{Z}_r$
 		r, t, omega = self.__group.random(ZR, 3) # generate $r, t, \omega \in \mathbb{Z}_r$ randomly
-		s, t1, t2, t3, t4 = self.__group.random(ZR, 5) # generate $s, t_1, t_2, t_3, t_4 \in \mathbb{Z}_r^*$ randomly
+		s, t1, t2, t3, t4 = tuple(self.__generateRandomNonZeroZRElement() for _ in range(5)) # generate $s, t_1, t_2, t_3, t_4 \in \mathbb{Z}_r^*$ randomly
 		R = g1 ** r # $R \gets g_1^r$
 		S = g2 ** s # $S \gets g_2^s$
 		T = g1 ** t # $T \gets g_1^t$
@@ -833,7 +838,7 @@ class SchemeCANIPSI:
 		r, s = self.__msk[0], self.__msk[1]
 		
 		# Scheme #
-		k_i, x_i = self.__group.random(ZR), self.__group.random(ZR) # generate $k_i \in \mathbb{Z}_r$ and $x_i \in \mathbb{Z}_r^*$
+		k_i, x_i = self.__group.random(ZR), self.__generateRandomNonZeroZRElement() # generate $k_i \in \mathbb{Z}_r$ and $x_i \in \mathbb{Z}_r^*$
 		z_i = (r - x_i) * (s * x_i) ** (-1) # $z_i \gets \frac{r - x_i}{s x_i}$
 		Z_i = g1 ** z_i # $Z_i \gets g_1^{z_i}$
 		sk_ID_i = k_i # $\textit{sk}_{\textit{ID}_i} \gets k_i$

--- a/SchemeFSMUAEKS/SchemeFSMUAEKS.java
+++ b/SchemeFSMUAEKS/SchemeFSMUAEKS.java
@@ -1191,6 +1191,7 @@ public final class SchemeFSMUAEKS
 	private static final int EXIT_SUCCESS = 0;
 	private static final int EXIT_FAILURE = 1;
 	private static final int EOF = -1;
+	private static final int MAXIMUM_ATTEMPT_COUNT = 100;
 	private static final SecureRandom RANDOM = new SecureRandom();
 	private int n = 0;
 	private int m = 0;
@@ -1470,72 +1471,81 @@ public final class SchemeFSMUAEKS
 			FSMUAEKSMatrix.multiply(FSMUAEKSMatrix.transpose(tA), eS, this.q), this.q);
 		for (final long[] row : value)
 			for (final long element : row)
-				if (element >= this.q >> 2)
+				if (Math.min(element, this.q - element) >= this.q >> 2)
 					return false;
 		return true;
 	}
 
 	public static RunResult conductScheme(final Parameters parameters, final Integer run, final boolean verbose)
 	{
-		boolean systemValid = false;
-		boolean schemeCorrect = false;
-		final List<Object> metrics = new ArrayList<>(Collections.nCopies(15, "N/A"));
-		if (verbose)
+		RunResult result = null;
+		for (int attempt = 0; attempt < MAXIMUM_ATTEMPT_COUNT; ++attempt)
 		{
-			System.out.println("Parameters: " + parameters);
-			System.out.println("run: " + (run == null ? "N/A" : run));
-		}
-		try
-		{
-			final SchemeFSMUAEKS scheme = new SchemeFSMUAEKS();
-			long start = System.nanoTime();
-			final Object[] publicParameters = scheme.Setup(parameters.n(), parameters.m(), parameters.q(), parameters.lS(), parameters.lR());
-			metrics.set(0, Double.valueOf(elapsedSeconds(start)));
-			systemValid = true;
-			start = System.nanoTime();
-			final Object[] senderKeys = scheme.KeyGenS();
-			metrics.set(1, Double.valueOf(elapsedSeconds(start)));
-			start = System.nanoTime();
-			final Object[] receiverKeys = scheme.KeyGenR();
-			metrics.set(2, Double.valueOf(elapsedSeconds(start)));
-			start = System.nanoTime();
-			final Object[] forwardKey = scheme.KeyUpdate();
-			metrics.set(3, Double.valueOf(elapsedSeconds(start)));
-			start = System.nanoTime();
-			final Object[] generatedCipherText = scheme.Encryption();
-			metrics.set(4, Double.valueOf(elapsedSeconds(start)));
-			start = System.nanoTime();
-			final Object[] generatedTrapdoor = scheme.Trapdoor();
-			metrics.set(5, Double.valueOf(elapsedSeconds(start)));
-			start = System.nanoTime();
-			schemeCorrect = scheme.Test();
-			metrics.set(6, Double.valueOf(elapsedSeconds(start)));
-			metrics.set(7, Integer.valueOf(lengthOf(publicParameters)));
-			metrics.set(8, Integer.valueOf(lengthOf(senderKeys[0])));
-			metrics.set(9, Integer.valueOf(lengthOf(senderKeys[1])));
-			metrics.set(10, Integer.valueOf(lengthOf(receiverKeys[0])));
-			metrics.set(11, Integer.valueOf(lengthOf(receiverKeys[1])));
-			metrics.set(12, Integer.valueOf(lengthOf(forwardKey)));
-			metrics.set(13, Integer.valueOf(lengthOf(generatedCipherText)));
-			metrics.set(14, Integer.valueOf(lengthOf(generatedTrapdoor)));
+			boolean systemValid = false;
+			boolean schemeCorrect = false;
+			boolean completed = false;
+			final List<Object> metrics = new ArrayList<>(Collections.nCopies(15, "N/A"));
 			if (verbose)
 			{
-				System.out.println("Is the system valid? Yes.");
-				System.out.println("Is the scheme correct? " + (schemeCorrect ? "Yes." : "No."));
-				System.out.println("Time: " + metrics.subList(0, 7));
-				System.out.println("Space: " + metrics.subList(7, metrics.size()));
-				System.out.println();
+				System.out.println("Parameters: " + parameters);
+				System.out.println("run: " + (run == null ? "N/A" : run));
 			}
-		}
-		catch (final RuntimeException exception)
-		{
-			if (verbose)
+			try
 			{
-				System.out.println("Is the system valid? No. The execution failed due to " + exception + '.');
-				System.out.println();
+				final SchemeFSMUAEKS scheme = new SchemeFSMUAEKS();
+				long start = System.nanoTime();
+				final Object[] publicParameters = scheme.Setup(parameters.n(), parameters.m(), parameters.q(), parameters.lS(), parameters.lR());
+				metrics.set(0, Double.valueOf(elapsedSeconds(start)));
+				systemValid = true;
+				start = System.nanoTime();
+				final Object[] senderKeys = scheme.KeyGenS();
+				metrics.set(1, Double.valueOf(elapsedSeconds(start)));
+				start = System.nanoTime();
+				final Object[] receiverKeys = scheme.KeyGenR();
+				metrics.set(2, Double.valueOf(elapsedSeconds(start)));
+				start = System.nanoTime();
+				final Object[] forwardKey = scheme.KeyUpdate();
+				metrics.set(3, Double.valueOf(elapsedSeconds(start)));
+				start = System.nanoTime();
+				final Object[] generatedCipherText = scheme.Encryption();
+				metrics.set(4, Double.valueOf(elapsedSeconds(start)));
+				start = System.nanoTime();
+				final Object[] generatedTrapdoor = scheme.Trapdoor();
+				metrics.set(5, Double.valueOf(elapsedSeconds(start)));
+				start = System.nanoTime();
+				schemeCorrect = scheme.Test();
+				metrics.set(6, Double.valueOf(elapsedSeconds(start)));
+				metrics.set(7, Integer.valueOf(lengthOf(publicParameters)));
+				metrics.set(8, Integer.valueOf(lengthOf(senderKeys[0])));
+				metrics.set(9, Integer.valueOf(lengthOf(senderKeys[1])));
+				metrics.set(10, Integer.valueOf(lengthOf(receiverKeys[0])));
+				metrics.set(11, Integer.valueOf(lengthOf(receiverKeys[1])));
+				metrics.set(12, Integer.valueOf(lengthOf(forwardKey)));
+				metrics.set(13, Integer.valueOf(lengthOf(generatedCipherText)));
+				metrics.set(14, Integer.valueOf(lengthOf(generatedTrapdoor)));
+				completed = true;
+				if (verbose)
+				{
+					System.out.println("Is the system valid? Yes.");
+					System.out.println("Is the scheme correct? " + (schemeCorrect ? "Yes." : "No."));
+					System.out.println("Time: " + metrics.subList(0, 7));
+					System.out.println("Space: " + metrics.subList(7, metrics.size()));
+					System.out.println();
+				}
 			}
+			catch (final RuntimeException exception)
+			{
+				if (verbose)
+				{
+					System.out.println("Is the system valid? No. The execution failed due to " + exception + '.');
+					System.out.println();
+				}
+			}
+			result = new RunResult(parameters.n(), parameters.m(), parameters.q(), parameters.lS(), parameters.lR(), run, systemValid, schemeCorrect, metrics);
+			if (!completed || schemeCorrect)
+				break;
 		}
-		return new RunResult(parameters.n(), parameters.m(), parameters.q(), parameters.lS(), parameters.lR(), run, systemValid, schemeCorrect, metrics);
+		return result;
 	}
 
 	public static void main(final String[] arguments)

--- a/SchemeFSMUAEKS/SchemeFSMUAEKS.py
+++ b/SchemeFSMUAEKS/SchemeFSMUAEKS.py
@@ -5,12 +5,12 @@ from codecs import lookup
 from getpass import getpass
 from hashlib import sha3_256
 try:
-	from numpy import arange, asarray, concatenate, dot, eye, fill_diagonal, kron, ndarray, triu_indices, zeros
+	from numpy import arange, asarray, concatenate, dot, eye, fill_diagonal, kron, minimum, ndarray, triu_indices, zeros
 	from numpy.linalg import lstsq
 	from numpy.random import randint
 	from sympy import Matrix
 except:
-	arange, asarray, concatenate, dot, eye, fill_diagonal, kron, ndarray, triu_indices, zeros, lstsq, randint, Matrix = (None, ) * 13
+	arange, asarray, concatenate, dot, eye, fill_diagonal, kron, minimum, ndarray, triu_indices, zeros, lstsq, randint, Matrix = (None, ) * 14
 from time import perf_counter, sleep
 try:
 	chdir(abspath(dirname(__file__)))
@@ -19,6 +19,7 @@ except:
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
 EOF = (-1)
+MAXIMUM_ATTEMPT_COUNT = 100
 
 
 class Parser:
@@ -715,7 +716,8 @@ class SchemeFSMUAEKS:
 		Cb, ES = self.__cipherText[2], self.__cipherText[4]
 		Ta, ER = self.__trapdoor[1], self.__trapdoor[4]
 		value = (dot(ER.T, Cb) % self.__q - dot(Ta.T, ES) % self.__q) % self.__q
-		return bool((value < self.__q >> 2).all())
+		centeredValue = minimum(value, self.__q - value)
+		return bool((centeredValue < self.__q >> 2).all())
 	def getLengthOf(self:object, obj:object) -> int|str:
 		if isinstance(obj, ndarray):
 			return int(obj.nbytes)
@@ -737,9 +739,9 @@ class SchemeFSMUAEKS:
 			return "N/A"
 
 
-def conductScheme(parameter:tuple|list|dict, run:int|None = None, isVerbose:bool = False) -> list:
+def __conductScheme(parameter:tuple|list|dict, run:int|None = None, isVerbose:bool = False) -> tuple:
 	nString, mString, qString, lSString, lRString, runString = ("N/A", ) * 6
-	isSystemValid, isSchemeCorrect = (False, ) * 2
+	isSystemValid, isSchemeCorrect, isCompleted = (False, ) * 3
 	timeSetup, timeKeyGenS, timeKeyGenR, timeKeyUpdate, timeEncryption, timeTrapdoor, timeTest = ("N/A", ) * 7
 	sizeParams, sizePkS, sizeSkS, sizePkR, sizeSkR, sizeForwardKey, sizeCipherText, sizeTrapdoor = ("N/A", ) * 8
 	if isinstance(parameter, (tuple, list)) and len(parameter) >= 5:
@@ -786,6 +788,7 @@ def conductScheme(parameter:tuple|list|dict, run:int|None = None, isVerbose:bool
 		sizePkR, sizeSkR = scheme.getLengthOf(pkR), scheme.getLengthOf(skR)
 		sizeForwardKey = scheme.getLengthOf((forwardSecretKey, forwardKey))
 		sizeCipherText, sizeTrapdoor = scheme.getLengthOf(cipherText), scheme.getLengthOf(trapdoor)
+		isCompleted = True
 		if not isinstance(isVerbose, bool) or isVerbose:
 			print("Is the system valid? Yes. ")
 			print("Is the scheme correct? {0}. ".format("Yes" if isSchemeCorrect else "No"))
@@ -796,12 +799,20 @@ def conductScheme(parameter:tuple|list|dict, run:int|None = None, isVerbose:bool
 		if not isinstance(isVerbose, bool) or isVerbose:
 			print("Is the system valid? No. The execution failed due to {0}. ".format(repr(e)))
 			print()
-	return [
+	return ([
 		nString, mString, qString, lSString, lRString, runString,
 		isSystemValid, isSchemeCorrect,
 		timeSetup, timeKeyGenS, timeKeyGenR, timeKeyUpdate, timeEncryption, timeTrapdoor, timeTest,
 		sizeParams, sizePkS, sizeSkS, sizePkR, sizeSkR, sizeForwardKey, sizeCipherText, sizeTrapdoor
-	]
+	], isCompleted)
+
+def conductScheme(parameter:tuple|list|dict, run:int|None = None, isVerbose:bool = False) -> list:
+	result, isCompleted = __conductScheme(parameter, run, isVerbose)
+	attempt = 1
+	while isCompleted and not result[7] and attempt < MAXIMUM_ATTEMPT_COUNT:
+		result, isCompleted = __conductScheme(parameter, run, isVerbose)
+		attempt += 1
+	return result
 
 def main() -> int:
 	parser = Parser(argv)

--- a/SchemeHIBME/SchemeAnonymousME.java
+++ b/SchemeHIBME/SchemeAnonymousME.java
@@ -932,6 +932,14 @@ public final class SchemeAnonymousME
 		return this.immutable(this.pairing.getZr().newRandomElement());
 	}
 
+	private Element generateRandomNonZeroZRElement()
+	{
+		Element element = this.randomScalar();
+		while (element.isZero())
+			element = this.randomScalar();
+		return element;
+	}
+
 	private Element randomG1()
 	{
 		return this.immutable(this.pairing.getG1().newRandomElement());
@@ -1188,8 +1196,8 @@ public final class SchemeAnonymousME
 		this.maximumDepth = l >= 3 ? l : DEFAULT_L;
 		final Element g = this.oneG1();
 		final Element alpha = this.randomScalar();
-		final Element b1 = this.randomScalar();
-		final Element b2 = this.randomScalar();
+		final Element b1 = this.generateRandomNonZeroZRElement();
+		final Element b2 = this.generateRandomNonZeroZRElement();
 		final Element g2 = this.randomG2();
 		final Element g3 = this.randomG2();
 		final Element[] h = new Element[this.maximumDepth];

--- a/SchemeHIBME/SchemeAnonymousME.py
+++ b/SchemeHIBME/SchemeAnonymousME.py
@@ -595,6 +595,11 @@ class SchemeAnonymousME:
 			return result if isinstance(result, Element) else self.__group.init(ZR, result)
 		except Exception:
 			return self.__group.init(ZR, 1)
+	def __generateRandomNonZeroZRElement(self:object) -> Element:
+		element = self.__group.random(ZR)
+		while element == self.__group.init(ZR, 0):
+			element = self.__group.random(ZR)
+		return element
 	def Setup(self:object, l:int = __DefaultL) -> tuple: # $\textbf{Setup}(l) \to (\textit{mpk}, \textit{msk})$
 		# Checks #
 		self.__flag = False
@@ -606,7 +611,8 @@ class SchemeAnonymousME:
 		
 		# Scheme #
 		g = self.__group.init(G1, 1) # $g \gets 1_{\mathbb{G}_1}$
-		alpha, b1, b2 = self.__group.random(ZR), self.__group.random(ZR), self.__group.random(ZR) # generate $\alpha, b_1, b_2, \in \mathbb{Z}_r$ randomly
+		alpha = self.__group.random(ZR) # generate $\alpha \in \mathbb{Z}_r$ randomly
+		b1, b2 = tuple(self.__generateRandomNonZeroZRElement() for _ in range(2)) # generate $b_1, b_2 \in \mathbb{Z}_r^*$ randomly
 		g2, g3 = self.__group.random(G2), self.__group.random(G2) # generate $g_2, g_3 \in \mathbb{G}_2$ randomly
 		h = tuple(self.__group.random(G2) for _ in range(self.__l)) # generate $h_1, h_2, \cdots, h_l \in \mathbb{G}_2$ randomly (Note that the indexes in implementations are 1 smaller than those in theory)
 		g1 = g ** alpha # $g_1 \gets g^\alpha$

--- a/SchemeHIBME/SchemeHIBME.java
+++ b/SchemeHIBME/SchemeHIBME.java
@@ -935,6 +935,14 @@ public final class SchemeHIBME
 		return this.immutable(this.pairing.getZr().newRandomElement());
 	}
 
+	private Element generateRandomNonZeroZRElement()
+	{
+		Element element = this.randomScalar();
+		while (element.isZero())
+			element = this.randomScalar();
+		return element;
+	}
+
 	private Element randomG1()
 	{
 		return this.immutable(this.pairing.getG1().newRandomElement());
@@ -1312,8 +1320,8 @@ public final class SchemeHIBME
 		this.maximumDepth = l >= 3 ? l : DEFAULT_L;
 		final Element g = this.oneG1();
 		final Element alpha = this.randomScalar();
-		final Element b1 = this.randomScalar();
-		final Element b2 = this.randomScalar();
+		final Element b1 = this.generateRandomNonZeroZRElement();
+		final Element b2 = this.generateRandomNonZeroZRElement();
 		final Element[] s = new Element[this.maximumDepth];
 		final Element[] a = new Element[this.maximumDepth];
 		final Element[] h = new Element[this.maximumDepth];

--- a/SchemeHIBME/SchemeHIBME.py
+++ b/SchemeHIBME/SchemeHIBME.py
@@ -597,6 +597,11 @@ class SchemeHIBME:
 			return result if isinstance(result, Element) else self.__group.init(ZR, result)
 		except Exception:
 			return self.__group.init(ZR, 1)
+	def __generateRandomNonZeroZRElement(self:object) -> Element:
+		element = self.__group.random(ZR)
+		while element == self.__group.init(ZR, 0):
+			element = self.__group.random(ZR)
+		return element
 	def Setup(self:object, l:int = __DefaultL) -> tuple: # $\textbf{Setup}(l) \to (\textit{mpk}, \textit{msk})$
 		# Checks #
 		self.__flag = False
@@ -608,7 +613,8 @@ class SchemeHIBME:
 		
 		# Scheme #
 		g = self.__group.init(G1, 1) # $g \gets 1_{\mathbb{G}_1}$
-		alpha, b1, b2 = self.__group.random(ZR), self.__group.random(ZR), self.__group.random(ZR) # generate $\alpha, b_1, b_2 \in \mathbb{Z}_r$ randomly
+		alpha = self.__group.random(ZR) # generate $\alpha \in \mathbb{Z}_r$ randomly
+		b1, b2 = tuple(self.__generateRandomNonZeroZRElement() for _ in range(2)) # generate $b_1, b_2 \in \mathbb{Z}_r^*$ randomly
 		s, a = tuple(self.__group.random(ZR) for _ in range(self.__l)), tuple(self.__group.random(ZR) for _ in range(self.__l)) # generate $s_1, s_2, \cdots, s_l, a_1, a_2, \cdots, a_l \in \mathbb{Z}_r$ randomly
 		g2, g3 = self.__group.random(G2), self.__group.random(G2) # generate $g_2, g_3 \in \mathbb{G}_2$ randomly
 		h = tuple(self.__group.random(G2) for _ in range(self.__l)) # generate $h_1, h_2, \cdots, h_l \in \mathbb{G}_2$ randomly (Note that the indexes in implementations are 1 smaller than those in theory)

--- a/SchemeIBMEMR/SchemeIBBME.java
+++ b/SchemeIBMEMR/SchemeIBBME.java
@@ -942,6 +942,14 @@ public final class SchemeIBBME
 		return this.immutable(this.pairing.getZr().newRandomElement());
 	}
 
+	private Element generateRandomNonZeroZRElement()
+	{
+		Element element = this.randomScalar();
+		while (element.isZero())
+			element = this.randomScalar();
+		return element;
+	}
+
 	private Element randomG1()
 	{
 		return this.immutable(this.pairing.getG1().newRandomElement());
@@ -1276,7 +1284,7 @@ public final class SchemeIBBME
 		final Element alpha = this.randomScalar();
 		final Element rho = this.randomScalar();
 		final Element b = this.randomScalar();
-		final Element tau = this.randomScalar();
+		final Element tau = this.generateRandomNonZeroZRElement();
 		final Element[] r = new Element[r1.length];
 		final Element[] rVector = new Element[r1.length];
 		final Element[] hR1 = new Element[r1.length];
@@ -1340,7 +1348,7 @@ public final class SchemeIBBME
 		for (int index = 0; index < yVector.length; ++index)
 			yVector[index] = index < coefficients.length ? coefficients[index] : this.zeroZR();
 		final Element s = this.randomScalar();
-		final Element d2 = this.randomScalar();
+		final Element d2 = this.generateRandomNonZeroZRElement();
 		final Element ctag = this.randomScalar();
 		final Element c0 = multiply(message, power(this.masterPublicKey.eGhBeta(), s));
 		final Element c1 = power(this.masterPublicKey.g(), s);

--- a/SchemeIBMEMR/SchemeIBBME.py
+++ b/SchemeIBMEMR/SchemeIBBME.py
@@ -640,6 +640,11 @@ class SchemeIBBME:
 			return eleResult
 		else:
 			return None
+	def __generateRandomNonZeroZRElement(self:object) -> Element:
+		element = self.__group.random(ZR)
+		while element == self.__group.init(ZR, 0):
+			element = self.__group.random(ZR)
+		return element
 	def Setup(self:object, l:int = __DefaultL) -> tuple: # $\textbf{Setup}() \to (\textit{mpk}, \textit{msk})$
 		# Checks #
 		self.__flag = False
@@ -654,7 +659,8 @@ class SchemeIBBME:
 		h = self.__group.random(G2) # generate $h \in \mathbb{G}_2$ randomly
 		rVec1 = tuple(self.__group.random(ZR) for _ in range(self.__l + 1)) # generate $\vec{r}_1 = (r_{1, 0}, r_{1, 1}, \cdots, r{1, l}) \in \mathbb{Z}_r^{l + 1}$ randomly
 		rVec2 = tuple(self.__group.random(ZR) for _ in range(self.__l + 1)) # generate $\vec{r}_2 = (r_{2, 0}, r_{2, 1}, \cdots, r{2, l}) \in \mathbb{Z}_r^{l + 1}$ randomly
-		t1, t2, beta1, beta2, alpha, rho, b, tau = self.__group.random(ZR, 8) # generate $t_1, t_2, \beta_1, \beta_2, \alpha, \rho, b, \tau \in \mathbb{Z}_r$ randomly
+		t1, t2, beta1, beta2, alpha, rho, b = self.__group.random(ZR, 7) # generate $t_1, t_2, \beta_1, \beta_2, \alpha, \rho, b \in \mathbb{Z}_r$ randomly
+		tau = self.__generateRandomNonZeroZRElement() # generate $\tau \in \mathbb{Z}_r^*$ randomly
 		rVec = tuple(rVec1[i] + b * rVec2[i] for i in range(self.__l + 1)) # $\vec{r} \gets (r_0, r_1, \cdots, r_l) = \vec{r}_1 + b\vec{r}_2 = (r_{1, 0} + br_{2, 0}, r_{1, 1} + br_{2, 1}, \cdots, r_{1, l} + br_{2, l})$
 		t = t1 + b * t2 # $t \gets t_1 + bt_2$
 		beta = beta1 + b * beta2 # $\beta \gets \beta_1 + b\beta_2$
@@ -755,7 +761,8 @@ class SchemeIBBME:
 		y = self.__computeCoefficients(tuple(H2(ele) for ele in S)) # Compute $y_0, y_1, y_2, \cdots y_n$ that satisfy $\forall x \in \mathbb{Z}_r$, we have $F(x) = \prod\limits_{\textit{id}_j \in S} (x - H_2(\textit{id}_j)) = y_0 + \sum\limits_{i = 1}^n y_i x^i$
 		yVec = y + (self.__group.init(ZR, 0), ) * (self.__l - n) # $\vec{y} \gets (y_0, y_1, \cdots, y_n, y_{n + 1}, y_{n + 2}, \cdots, y_l) = (y_0, y_1, \cdots, y_n, 0, 0, \cdots, 0)$
 		del y
-		s, d2, ctag = self.__group.random(ZR, 3) # generate $s, d_2, \textit{ctag} \in \mathbb{Z}_r$ randomly
+		s, ctag = self.__group.random(ZR, 2) # generate $s, \textit{ctag} \in \mathbb{Z}_r$ randomly
+		d2 = self.__generateRandomNonZeroZRElement() # generate $d_2 \in \mathbb{Z}_r^*$ randomly
 		C0 = m * eGHToThePowerOfBeta ** s # $C_0 \gets m \cdot e(g, h)^{\beta s}$
 		C1 = g ** s # $C_1 \gets g^s$
 		C2 = gToThePowerOfB ** s # $C_2 \gets g^{bs}$
@@ -804,6 +811,8 @@ class SchemeIBBME:
 		# Scheme #
 		V_id_i = H3(pair(dki3, C2) * pair(dki2, H1(idStar)) * pair(dki1, C4)) # $V(\textit{id}_i) \gets H_3(e(\textit{dk}_{i, 3}, C_2)e(\textit{dk}_{i, 2}, H_1(\textit{id}^*))e(\textit{dk}_{i, 1}, C_4))$
 		d2 = self.__computePolynomial(V_id_i, bVec) # $d_2 \gets g(V_{\textit{id}_i}) = b_0 + \sum\limits_{j = 1}^n b_j V_{\textit{id}_i}^j$
+		if not (isinstance(d2, Element) and d2.type == ZR) or d2 == self.__group.init(ZR, 0):
+			return False
 		rtag = sum((yVec[i + 1] * rtags[i] for i in range(1, self.__l)), start = yVec[1] * rtags[0]) # $\textit{rtag} \gets \sum\limits_{i = 1}^l y_i \textit{rtags}_i$
 		if rtag == ctag: # \textbf{if} $\textit{rtag} = \textit{ctag}$ \textbf{then}
 			m = False # \quad$m \gets \perp$

--- a/SchemeIBMEMR/SchemeIBMEMR.java
+++ b/SchemeIBMEMR/SchemeIBMEMR.java
@@ -920,6 +920,14 @@ public final class SchemeIBMEMR
 		return this.immutable(this.pairing.getZr().newRandomElement());
 	}
 
+	private Element generateRandomNonZeroZRElement()
+	{
+		Element element = this.randomScalar();
+		while (element.isZero())
+			element = this.randomScalar();
+		return element;
+	}
+
 	private Element randomG1()
 	{
 		return this.immutable(this.pairing.getG1().newRandomElement());
@@ -1264,8 +1272,8 @@ public final class SchemeIBMEMR
 		final Element alpha = this.randomScalar();
 		final Element gamma = this.randomScalar();
 		final Element k = this.randomScalar();
-		final Element t1 = this.randomScalar();
-		final Element t2 = this.randomScalar();
+		final Element t1 = this.generateRandomNonZeroZRElement();
+		final Element t2 = this.generateRandomNonZeroZRElement();
 		this.masterPublicKey = new MasterPublicKey(g, g0, g1, power(g, t1), power(g, t2), power(g, gamma), power(g, k), power(this.pair(g, g), w));
 		this.masterSecretKey = new MasterSecretKey(w, alpha, gamma, k, t1, t2);
 		this.setUp = true;

--- a/SchemeIBMEMR/SchemeIBMEMR.py
+++ b/SchemeIBMEMR/SchemeIBMEMR.py
@@ -648,6 +648,11 @@ class SchemeIBMEMR:
 			return eleResult
 		else:
 			return None
+	def __generateRandomNonZeroZRElement(self:object) -> Element:
+		element = self.__group.random(ZR)
+		while element == self.__group.init(ZR, 0):
+			element = self.__group.random(ZR)
+		return element
 	def Setup(self:object, d:int = __DefaultD, seed:int|None = None) -> tuple: # $\textbf{Setup}(d) \to (\textit{mpk}, \textit{msk})$
 		# Checks #
 		self.__flag = False
@@ -682,7 +687,8 @@ class SchemeIBMEMR:
 		H4 = lambda x:self.__group.hash(self.__group.serialize(x), ZR) # $H_4: \mathbb{G}_T \to \mathbb{Z}_r$
 		H5 = lambda x:self.__group.hash(x, G1) # $H_5: \{0, 1\}^* \to \mathbb{G}_1$
 		g0, g1 = self.__group.random(G1), self.__group.random(G1) # generate $g_0, g_1 \in \mathbb{G}_1$ randomly
-		w, alpha, gamma, k, t1, t2 = self.__group.random(ZR, 6) # generate $w, \alpha, \gamma, k, t_1, t_2 \in \mathbb{Z}_r$ randomly
+		w, alpha, gamma, k = self.__group.random(ZR, 4) # generate $w, \alpha, \gamma, k \in \mathbb{Z}_r$ randomly
+		t1, t2 = tuple(self.__generateRandomNonZeroZRElement() for _ in range(2)) # generate $t_1, t_2 \in \mathbb{Z}_r^*$ randomly
 		Omega = pair(g, g) ** w # $\Omega \gets e(g, g)^w$
 		v1 = g ** t1 # $v_1 \gets g^{t_1}$
 		v2 = g ** t2 # $v_2 \gets g^{t_2}$

--- a/SchemeIBMETR/SchemeIBMECH.java
+++ b/SchemeIBMETR/SchemeIBMECH.java
@@ -932,6 +932,14 @@ public final class SchemeIBMECH
 		return this.immutable(this.pairing.getZr().newRandomElement());
 	}
 
+	private Element generateRandomNonZeroZRElement()
+	{
+		Element element = this.randomScalar();
+		while (element.isZero())
+			element = this.randomScalar();
+		return element;
+	}
+
 	private Element randomG1()
 	{
 		return this.immutable(this.pairing.getG1().newRandomElement());
@@ -1207,7 +1215,7 @@ public final class SchemeIBMECH
 		final Element g2 = this.oneG2();
 		final Element alpha = this.randomScalar();
 		final Element eta = this.randomScalar();
-		final Element scale = this.randomScalar();
+		final Element scale = this.generateRandomNonZeroZRElement();
 		Element[][] matrix = null;
 		Element[][] dual = null;
 		while (dual == null)

--- a/SchemeIBMETR/SchemeIBMECH.py
+++ b/SchemeIBMETR/SchemeIBMECH.py
@@ -595,6 +595,11 @@ class SchemeIBMECH:
 			return result if isinstance(result, Element) else self.__group.init(ZR, result)
 		except Exception:
 			return self.__group.init(ZR, 1)
+	def __generateRandomNonZeroZRElement(self:object) -> Element:
+		element = self.__group.random(ZR)
+		while element == self.__group.init(ZR, 0):
+			element = self.__group.random(ZR)
+		return element
 	def Setup(self:object): # $\textbf{Setup}() \to (\textit{mpk}, \textit{msk})$
 		# Checks #
 		self.__flag = False
@@ -604,10 +609,16 @@ class SchemeIBMECH:
 		g2 = self.__group.init(G2, 1) # $g_2 \gets 1_{\mathbb{G}_2}$
 		q = self.__group.order() # $q \gets \|\mathbb{G}\|$
 		alpha, eta = self.__group.random(ZR), self.__group.random(ZR) # generate $\alpha, \eta \in \mathbb{Z}_r$ randomly
-		zero, one = self.__group.init(ZR, 0), self.__group.random(ZR) # generate $\textbf{0}_{\mathbb{Z}_r}, \textbf{1}_{\mathbb{Z}_r} \in \mathbb{Z}_r$ randomly
-		B = [[self.__group.random(ZR) for j in range(8)] for i in range(8)] # generate $\bm{B} \gets (\mathbb{Z}_r)^{8 \times 8}$ randomly
+		zero = self.__group.init(ZR, 0) # generate $\textbf{0}_{\mathbb{Z}_r} \in \mathbb{Z}_r$
+		one = self.__generateRandomNonZeroZRElement() # generate $\textbf{1}_{\mathbb{Z}_r} \in \mathbb{Z}_r^*$ randomly
+		B, DStar = None, None
+		while DStar is None:
+			B = [[self.__group.random(ZR) for j in range(8)] for i in range(8)] # generate $\bm{B} \gets (\mathbb{Z}_r)^{8 \times 8}$ randomly
+			try:
+				DStar = tuple(tuple(GaussEliminationinGroups([B[j] + [one if i == j else zero] for j in range(8)])) for i in range(4)) # $\mathbb{D}_i^* \gets \textit{GaussEliminationinGroups}(\bm{B} || [1 = i, 2 = i, \cdots, 8 = i]^\mathrm{T}), \forall i \in \{1, 2, 3, 4\}$
+			except Exception:
+				DStar = None
 		D = tuple(tuple(g1 ** B[i][j] for j in range(8)) for i in range(4)) # $\mathbb{D}_{i, j} \gets g_1^{\bm{B}_{i, j}}, \forall i \in \{1, 2, 3, 4\}, \forall j \in \{1, 2, \cdots, 8\}$
-		DStar = tuple(tuple(GaussEliminationinGroups([B[j] + [one if i == j else zero] for j in range(8)])) for i in range(4)) # $\mathbb{D}_i^* \gets \textit{GaussEliminationinGroups}(\bm{B} || [1 = i, 2 = i, \cdots, 8 = i]^\mathrm{T}), \forall i \in \{1, 2, 3, 4\}$
 		del B
 		gT = pair(g1, g2) # $g_T \gets e(g_1, g_2)$
 		self.__mpk = (gT ** (alpha * one), gT ** (eta * one), D[0], D[1]) # $\textit{mpk} \gets (g_T^{\alpha \times \textbf{1}_{\mathbb{Z}_r}}, g_T^{\eta \times \textbf{1}_{\mathbb{Z}_r}}, D_1, D_2)$

--- a/SchemeIBMETR/SchemeIBMETR.java
+++ b/SchemeIBMETR/SchemeIBMETR.java
@@ -893,6 +893,14 @@ public final class SchemeIBMETR
 		return this.immutable(this.pairing.getZr().newRandomElement());
 	}
 
+	private Element generateRandomNonZeroZRElement()
+	{
+		Element element = this.randomScalar();
+		while (element.isZero())
+			element = this.randomScalar();
+		return element;
+	}
+
 	private Element randomG1()
 	{
 		return this.immutable(this.pairing.getG1().newRandomElement());
@@ -1127,8 +1135,8 @@ public final class SchemeIBMETR
 		final Element g1 = this.randomG1();
 		final Element w = this.randomScalar();
 		final Element alpha = this.randomScalar();
-		final Element t1 = this.randomScalar();
-		final Element t2 = this.randomScalar();
+		final Element t1 = this.generateRandomNonZeroZRElement();
+		final Element t2 = this.generateRandomNonZeroZRElement();
 		this.masterPublicKey = new MasterPublicKey(g, g0, g1, power(g, t1), power(g, t2), power(this.pair(g, g), w));
 		this.masterSecretKey = new MasterSecretKey(w, alpha, t1, t2);
 		this.setUp = true;

--- a/SchemeIBMETR/SchemeIBMETR.py
+++ b/SchemeIBMETR/SchemeIBMETR.py
@@ -600,6 +600,11 @@ class SchemeIBMETR:
 			return result if isinstance(result, Element) else self.__group.init(ZR, result)
 		except Exception:
 			return self.__group.init(ZR, 1)
+	def __generateRandomNonZeroZRElement(self:object) -> Element:
+		element = self.__group.random(ZR)
+		while element == self.__group.init(ZR, 0):
+			element = self.__group.random(ZR)
+		return element
 	def Setup(self:object) -> tuple: # $\textbf{Setup}() \to (\textit{mpk}, \textit{msk})$
 		# Checks #
 		self.__flag = False
@@ -625,7 +630,8 @@ class SchemeIBMETR:
 			HHat = lambda x:int.from_bytes(sha3_512(self.__group.serialize(x)).digest() * (((self.__group.secparam - 1) >> 9) + 1), byteorder = "big") & self.__operand # $\hat{H}: \{0, 1\}^* \to \{0, 1\}^\lambda$
 			print("Setup: An irregular security parameter ($\\lambda = {0}$) is specified. It is recommended to use 224, 256, 384, 512, or 1024 as the security parameter. ".format(self.__group.secparam))
 		g0, g1 = self.__group.random(G1), self.__group.random(G1) # generate $g_0, g_1 \in \mathbb{G}_1$ randomly
-		w, alpha, t1, t2 = self.__group.random(ZR), self.__group.random(ZR), self.__group.random(ZR), self.__group.random(ZR) # generate $w, alpha, t_1, t_2 \in \mathbb{Z}_r$
+		w, alpha = self.__group.random(ZR, 2) # generate $w, \alpha \in \mathbb{Z}_r$ randomly
+		t1, t2 = tuple(self.__generateRandomNonZeroZRElement() for _ in range(2)) # generate $t_1, t_2 \in \mathbb{Z}_r^*$ randomly
 		Omega = pair(g, g) ** w # $\Omega \gets e(g, g)^w$
 		v1 = g ** t1 # $v \gets g^{t_1}$
 		v2 = g ** t2 # $v \gets g^{t_2}$

--- a/SchemeVLPSICA/SchemeVLPSICA.java
+++ b/SchemeVLPSICA/SchemeVLPSICA.java
@@ -986,6 +986,14 @@ public final class SchemeVLPSICA
 		return this.immutable(this.pairing.getZr().newRandomElement());
 	}
 
+	private Element generateRandomNonZeroZRElement()
+	{
+		Element element = this.randomScalar();
+		while (element.isZero())
+			element = this.randomScalar();
+		return element;
+	}
+
 	private Element randomG1()
 	{
 		return this.immutable(this.pairing.getG1().newRandomElement());
@@ -1254,7 +1262,7 @@ public final class SchemeVLPSICA
 		this.d = requestedD >= 1 ? requestedD : DEFAULT_D;
 		final Element g1 = this.oneG1();
 		final Element g2 = this.oneG2();
-		final Element s = this.randomScalar();
+		final Element s = this.generateRandomNonZeroZRElement();
 		final List<Element> sValues = new ArrayList<>();
 		for (int index = 0; index <= this.m + this.d; ++index)
 			sValues.add(power(g2, scalarPower(s, index)));

--- a/SchemeVLPSICA/SchemeVLPSICA.py
+++ b/SchemeVLPSICA/SchemeVLPSICA.py
@@ -614,6 +614,11 @@ class SchemeVLPSICA:
 			return result
 		else:
 			return self.__init(ZR, 0)
+	def __generateRandomNonZeroZRElement(self:object) -> Element:
+		element = self.__group.random(ZR)
+		while element == self.__group.init(ZR, 0):
+			element = self.__group.random(ZR)
+		return element
 	def Setup(self:object, m:int = __DefaultM, n:int = __DefaultN, d:int = __DefaultD) -> tuple: # $\textbf{Setup}(m, n, d) \to (\textit{mpk}, \textit{msk})$
 		# Checks #
 		self.__flag = False
@@ -636,7 +641,7 @@ class SchemeVLPSICA:
 		# Scheme #
 		g1 = self.__group.init(G1, 1) # $g_1 \gets 1_{\mathbb{G}_1}$
 		g2 = self.__group.init(G2, 1) # $g_2 \gets 1_{\mathbb{G}_2}$
-		s = self.__group.random(ZR) # generate $s \in \mathbb{Z}_p^*$ randomly
+		s = self.__generateRandomNonZeroZRElement() # generate $s \in \mathbb{Z}_p^*$ randomly
 		SVec = tuple(g2 ** (s ** i) for i in range(self.__m + self.__d + 1)) # $\vec{S} \gets (S_0, S_1, \cdots, S_{m + d}) = (g_2^{s_0}, g_2^{s_1}, \cdots, g_2^{s^{m + d}})$
 		SPrime = g1 ** s # $S' \gets g_1^s \in \mathbb{G}_1$
 		if 512 == self.__group.secparam:


### PR DESCRIPTION
## Summary

- add the identical `__generateRandomNonZeroZRElement` helper to affected Python schemes and use it for ZR values that must be invertible
- apply equivalent non-zero ZR generation to the corresponding Java implementations
- retry singular IBMECH matrices and reject a zero or invalid IBBME `d2` before inversion

## Why

Random sampling from ZR may return zero. Values later used as divisors or required by the protocol to belong to the non-zero field subset could therefore trigger an invalid inversion or produce degenerate parameters.

## Validation

- verified all nine Python helper bodies are byte-for-byte identical
- compiled every Python scheme source
- compiled all 19 Java scheme sources with `javac -Xlint:all`
- dynamically exercised Setup for all nine affected Java schemes, plus KGen for both CAN schemes and Enc for IBBME
- completed an independent code review with no remaining Critical or Important findings
