### PR TITLE
Complete LaTeX extraction and validation

### DIFF
--- a/.github/workflows/runPython.yml
+++ b/.github/workflows/runPython.yml
@@ -307,6 +307,30 @@ jobs:
           echo "timeString=${timeString}" >> "${GITHUB_OUTPUT}"
         env:
           TZ: 'Asia/Hong_Kong'
+
+  testLaTeXBuilder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install the dependencies
+        run: |
+          cd "${{ github.workspace }}"
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Test the LaTeX and PDF builder
+        run: |
+          cd "${{ github.workspace }}"
+          python -m unittest -v testBuildSchemeLaTeXPDFs.py
   
   runPython:
     if: ${{ needs.prepare.outputs.matrix != '[]' }}

--- a/SchemeCANIFPPCT/SchemeCANIPSI.py
+++ b/SchemeCANIFPPCT/SchemeCANIPSI.py
@@ -816,10 +816,10 @@ class SchemeCANIPSI:
 		
 		# Scheme #
 		try:
-			VPrime_i = H2(pair(T0_i, C0_i) * pair(T1_i, C1_i) * pair(T2_i, C2_i) * pair(T3_i, C3_i) * pair(T4_i, C4_i))
-			return self.__computePolynomial(VPrime_i, aVec) == self.__group.init(ZR, 0)
+			VPrime_i = H2(pair(T0_i, C0_i) * pair(T1_i, C1_i) * pair(T2_i, C2_i) * pair(T3_i, C3_i) * pair(T4_i, C4_i)) # $V'_i \gets H_2(e(T_{0_i}, C_{0_i}) e(T_{1_i}, C_{1_i}) e(T_{2_i}, C_{2_i}) e(T_{3_i}, C_{3_i}) e(T_{4_i}, C_{4_i}))$
+			return self.__computePolynomial(VPrime_i, aVec) == self.__group.init(ZR, 0) # \textbf{return} $1$ if $f(V'_i) = 0$; otherwise, \textbf{return} $0$
 		except Exception:
-			return False
+			return False # \textbf{return} $0$
 	def Setup(self:object, n:int = __DefaultN, m:int = __DefaultM) -> tuple: # $\textbf{Setup}(n, m) \to (\textit{mpk}, \textit{msk})$
 		# Checks #
 		self.__flag = False
@@ -996,12 +996,12 @@ class SchemeCANIPSI:
 		
 		# Scheme #
 		try:
-			VVec = tuple(H2(Omega ** s[i]) for i in range(self.__n))
-			aVec = self.__computeCoefficients(VVec)
-			VPrime_i = H2(pair(C0_i, T0_i) * pair(T1_i, C1_i) * pair(T2_i, C2_i) * pair(T3_i, C3_i) * pair(T4_i, C4_i))
-			return self.__computePolynomial(VPrime_i, aVec) == self.__group.init(ZR, 0)
+			VVec = tuple(H2(Omega ** s[i]) for i in range(self.__n)) # $V_i \gets H_2(\Omega^{s_i}), \forall i \in \{1, 2, \cdots, n\}$
+			aVec = self.__computeCoefficients(VVec) # Compute $a_0, a_1, a_2, \cdots, a_n$ that satisfy $\forall x \in \mathbb{Z}_r$, we have $f(x) = \prod\limits_{i = 1}^n (x - V_i) = a_0 + \sum\limits_{i = 1}^n a_i x^i$
+			VPrime_i = H2(pair(C0_i, T0_i) * pair(T1_i, C1_i) * pair(T2_i, C2_i) * pair(T3_i, C3_i) * pair(T4_i, C4_i)) # $V'_i \gets H_2(e(C_{0_i}, T_{0_i}) e(T_{1_i}, C_{1_i}) e(T_{2_i}, C_{2_i}) e(T_{3_i}, C_{3_i}) e(T_{4_i}, C_{4_i}))$
+			return self.__computePolynomial(VPrime_i, aVec) == self.__group.init(ZR, 0) # \textbf{return} $1$ if $f(V'_i) = 0$; otherwise, \textbf{return} $0$
 		except Exception:
-			return False
+			return False # \textbf{return} $0$
 	def Trace(self:object, CTTPi:tuple, _L:list) -> tuple|bool: # $\textbf{Trace}(\textit{TP}_{\textit{TP}_i}, L) \to \textit{identity}$
 		# Checks #
 		if not self.__flag:
@@ -1019,15 +1019,15 @@ class SchemeCANIPSI:
 		
 		# Scheme #
 		try:
-			tag_i = H4(C2 / (C1 ** t))
+			tag_i = H4(C2 / (C1 ** t)) # $\textit{tag}_i \gets H_4(C_2 / C_1^t)$
 		except Exception:
-			return False
+			return False # \textbf{return} $0$
 		for element in _L:
 			if isinstance(element, tuple) and len(element) == 3 and tag_i == element[2]:
-				return element
+				return element # \textbf{return} $(\textit{ID}_i, k_i, \textit{tag}_i) \in L$ such that $\textit{tag}_i = H_4(C_2 / C_1^t)$
 		
 		# Return #
-		return False
+		return False # \textbf{return} $0$
 	def getLengthOf(self:object, obj:Element|int|bytes|tuple|list|set|dict|str) -> int|str:
 		if isinstance(obj, Element):
 			return len(self.__group.serialize(obj))

--- a/SchemeFSLLRS/SchemeFSLLRS.py
+++ b/SchemeFSLLRS/SchemeFSLLRS.py
@@ -618,56 +618,77 @@ class SchemeFSLLRS:
 			hashObject.update(len(encoded).to_bytes(8, byteorder = "big"))
 			hashObject.update(encoded)
 		return int.from_bytes(hashObject.digest(), byteorder = "big") % self.__modulus
-	def LLRSSetup(self:object, ringSize:int, dimension:int, modulus:int) -> tuple:
+	def LLRSSetup(self:object, ringSize:int, dimension:int, modulus:int) -> tuple: # $\textbf{LLRSSetup}(N, n, q) \to \textit{pp}$
+		# Checks #
 		if not all(isinstance(value, int) and value > 1 for value in (ringSize, dimension, modulus)):
 			raise ValueError("The ring size, dimension, and modulus must be integers greater than one. ")
 		if ringSize & (ringSize - 1):
 			raise ValueError("The ring size must be a power of two. ")
-		self.__ringSize, self.__dimension, self.__modulus = ringSize, dimension, modulus
-		diagonal = randint(1, modulus, size = (dimension, ))
-		self.__ringMatrix = eye(dimension, dtype = "int") * diagonal
-		self.__secretKeys, self.__publicKeys, self.__signer, self.__epoch = None, None, None, 0
-		self.__message, self.__ringSignature, self.__linkedSignature = None, None, None
-		return (self.__ringMatrix, ringSize, dimension, modulus)
-	def KeyExtract(self:object) -> tuple:
+
+		# Scheme #
+		self.__ringSize, self.__dimension, self.__modulus = ringSize, dimension, modulus # set $(N, n, q) \gets (\textit{ringSize}, \textit{dimension}, \textit{modulus})$, where $N$ is a power of two
+		diagonal = randint(1, modulus, size = (dimension, )) # generate $\bm{d} \gets (d_1, d_2, \ldots, d_n) \xleftarrow{\$} \{1, 2, \ldots, q - 1\}^n$
+		self.__ringMatrix = eye(dimension, dtype = "int") * diagonal # $\bm{A} \gets \operatorname{diag}(d_1, d_2, \ldots, d_n) \in \mathbb{Z}_q^{n \times n}$
+		self.__secretKeys, self.__publicKeys, self.__signer, self.__epoch = None, None, None, 0 # initialize the ring keys and signer as undefined and set the epoch $\tau \gets 0$
+		self.__message, self.__ringSignature, self.__linkedSignature = None, None, None # initialize the message and signature state as undefined
+
+		# Return #
+		return (self.__ringMatrix, ringSize, dimension, modulus) # $\textbf{return}\ \textit{pp} \gets (\bm{A}, N, n, q)$
+	def KeyExtract(self:object) -> tuple: # $\textbf{KeyExtract}(\textit{pp}) \to (\bm{P}, \bm{S})$
+		# Checks #
 		if self.__ringMatrix is None:
 			raise RuntimeError("The scheme has not been set up. ")
-		self.__secretKeys = randint(1, self.__modulus, size = (self.__ringSize, self.__dimension))
-		self.__publicKeys = dot(self.__secretKeys, self.__ringMatrix.T) % self.__modulus
-		return (self.__publicKeys, self.__secretKeys)
-	def KeyUpdate(self:object) -> tuple:
+
+		# Scheme #
+		self.__secretKeys = randint(1, self.__modulus, size = (self.__ringSize, self.__dimension)) # generate $\bm{S} \gets (\bm{s}_0^\mathsf{T}, \ldots, \bm{s}_{N - 1}^\mathsf{T})^\mathsf{T} \xleftarrow{\$} \{1, 2, \ldots, q - 1\}^{N \times n}$
+		self.__publicKeys = dot(self.__secretKeys, self.__ringMatrix.T) % self.__modulus # $\bm{P} \gets \bm{S}\bm{A}^\mathsf{T} \bmod q$, where row $i$ is $\bm{p}_i^\mathsf{T}$
+
+		# Return #
+		return (self.__publicKeys, self.__secretKeys) # $\textbf{return}\ (\bm{P}, \bm{S})$
+	def KeyUpdate(self:object) -> tuple: # $\textbf{KeyUpdate}(\bm{S}, \bm{P}, \tau) \to (i, \tau', \bm{s}'_i)$
+		# Checks #
 		if self.__secretKeys is None:
 			raise RuntimeError("The ring keys have not been extracted. ")
-		self.__signer = int(randint(self.__ringSize))
-		self.__epoch += 1
+
+		# Scheme #
+		self.__signer = int(randint(self.__ringSize)) # generate the signer index $i \xleftarrow{\$} \{0, 1, \ldots, N - 1\}$
+		self.__epoch += 1 # $\tau' \gets \tau + 1$
 		updatedSecret = array([
 			self.__hashScalar(self.__secretKeys[self.__signer], self.__epoch, index) or 1
 			for index in range(self.__dimension)
-		], dtype = "int")
-		self.__secretKeys[self.__signer] = updatedSecret
-		self.__publicKeys[self.__signer] = dot(self.__ringMatrix, updatedSecret) % self.__modulus
-		return (self.__signer, self.__epoch, updatedSecret)
-	def Sign(self:object, message:bytes|None = None) -> tuple:
+		], dtype = "int") # set $s'_{i,j} \gets H_q(\bm{s}_i, \tau', j)$ for every $j \in \{0, 1, \ldots, n - 1\}$, replacing the value $0$ by $1$, where $H_q: \{0, 1\}^* \to \mathbb{Z}_q$ is SHA3-256 reduced modulo $q$
+		self.__secretKeys[self.__signer] = updatedSecret # $\bm{s}_i \gets \bm{s}'_i$
+		self.__publicKeys[self.__signer] = dot(self.__ringMatrix, updatedSecret) % self.__modulus # $\bm{p}_i \gets \bm{A}\bm{s}'_i \bmod q$
+
+		# Return #
+		return (self.__signer, self.__epoch, updatedSecret) # $\textbf{return}\ (i, \tau', \bm{s}'_i)$
+	def Sign(self:object, message:bytes|None = None) -> tuple: # $\textbf{Sign}(\bm{S}, \bm{P}, m) \to \sigma$
+		# Checks #
 		if self.__signer is None or self.__publicKeys is None or self.__secretKeys is None:
 			raise RuntimeError("The signer key has not been updated. ")
-		q, ringSize, dimension, signer = self.__modulus, self.__ringSize, self.__dimension, self.__signer
-		self.__message = message if isinstance(message, bytes) else randint(0, 256, size = (32, ), dtype = "uint8").tobytes()
-		challenges = randint(q, size = (ringSize, ))
-		responses = randint(q, size = (ringSize, dimension))
-		commitments = zeros((ringSize, dimension), dtype = "int")
-		witness = randint(q, size = (dimension, ))
-		for index in range(ringSize):
-			if index == signer:
-				commitments[index] = dot(self.__ringMatrix, witness) % q
-			else:
-				commitments[index] = (dot(self.__ringMatrix, responses[index]) - challenges[index] * self.__publicKeys[index]) % q
-		challenge = self.__hashScalar(self.__message, self.__publicKeys, commitments)
-		challenges[signer] = (challenge - np_sum(challenges) + challenges[signer]) % q
-		responses[signer] = (witness + challenges[signer] * self.__secretKeys[signer]) % q
-		tag = sha3_256(self.__secretKeys[signer].astype("int64", copy = False).tobytes()).digest()
-		self.__ringSignature = (challenges, responses, tag)
-		return self.__ringSignature
-	def Verify(self:object, signature:tuple|None = None, message:bytes|None = None) -> bool:
+
+		# Scheme #
+		q, ringSize, dimension, signer = self.__modulus, self.__ringSize, self.__dimension, self.__signer # let $(q, N, n, i)$ denote the modulus, ring size, dimension, and signer index
+		self.__message = message if isinstance(message, bytes) else randint(0, 256, size = (32, ), dtype = "uint8").tobytes() # use the input $m$, or generate $m \xleftarrow{\$} \{0, 1\}^{256}$ when no message is supplied
+		challenges = randint(q, size = (ringSize, )) # generate $c_k \xleftarrow{\$} \mathbb{Z}_q$ for every $k \in \{0, 1, \ldots, N - 1\}$
+		responses = randint(q, size = (ringSize, dimension)) # generate $\bm{z}_k \xleftarrow{\$} \mathbb{Z}_q^n$ for every $k \in \{0, 1, \ldots, N - 1\}$
+		commitments = zeros((ringSize, dimension), dtype = "int") # initialize $\bm{T} \gets (\bm{t}_0^\mathsf{T}, \ldots, \bm{t}_{N - 1}^\mathsf{T})^\mathsf{T} \in \mathbb{Z}_q^{N \times n}$
+		witness = randint(q, size = (dimension, )) # generate $\bm{w} \xleftarrow{\$} \mathbb{Z}_q^n$
+		for index in range(ringSize): # for every $k \in \{0, 1, \ldots, N - 1\}$
+			if index == signer: # if $k = i$
+				commitments[index] = dot(self.__ringMatrix, witness) % q # set $\bm{t}_i \gets \bm{A}\bm{w} \bmod q$
+			else: # otherwise
+				commitments[index] = (dot(self.__ringMatrix, responses[index]) - challenges[index] * self.__publicKeys[index]) % q # set $\bm{t}_k \gets \bm{A}\bm{z}_k - c_k\bm{p}_k \bmod q$
+		challenge = self.__hashScalar(self.__message, self.__publicKeys, commitments) # $c \gets H_q(m, \bm{P}, \bm{T})$
+		challenges[signer] = (challenge - np_sum(challenges) + challenges[signer]) % q # $c_i \gets c - \sum_{k \ne i} c_k \bmod q$
+		responses[signer] = (witness + challenges[signer] * self.__secretKeys[signer]) % q # $\bm{z}_i \gets \bm{w} + c_i\bm{s}_i \bmod q$
+		tag = sha3_256(self.__secretKeys[signer].astype("int64", copy = False).tobytes()).digest() # $\eta \gets \mathtt{SHA3\text{-}256}(\bm{s}_i)$
+		self.__ringSignature = (challenges, responses, tag) # $\sigma \gets (\bm{c}, \bm{Z}, \eta)$
+
+		# Return #
+		return self.__ringSignature # $\textbf{return}\ \sigma$
+	def Verify(self:object, signature:tuple|None = None, message:bytes|None = None) -> bool: # $\textbf{Verify}(\bm{P}, m, \sigma) \to b, b \in \{0, 1\}$
+		# Checks #
 		if self.__publicKeys is None or self.__ringMatrix is None:
 			return False
 		checkedSignature = signature if isinstance(signature, tuple) else self.__ringSignature
@@ -681,17 +702,26 @@ class SchemeFSLLRS:
 			return False
 		if not isinstance(tag, bytes):
 			return False
-		commitments = zeros((self.__ringSize, self.__dimension), dtype = "int")
-		for index in range(self.__ringSize):
-			commitments[index] = (dot(self.__ringMatrix, responses[index]) - challenges[index] * self.__publicKeys[index]) % self.__modulus
-		return bool(np_sum(challenges) % self.__modulus == self.__hashScalar(checkedMessage, self.__publicKeys, commitments))
-	def Link(self:object) -> bool:
+
+		# Scheme #
+		commitments = zeros((self.__ringSize, self.__dimension), dtype = "int") # initialize $\bm{T} \gets (\bm{t}_0^\mathsf{T}, \ldots, \bm{t}_{N - 1}^\mathsf{T})^\mathsf{T} \in \mathbb{Z}_q^{N \times n}$
+		for index in range(self.__ringSize): # for every $k \in \{0, 1, \ldots, N - 1\}$
+			commitments[index] = (dot(self.__ringMatrix, responses[index]) - challenges[index] * self.__publicKeys[index]) % self.__modulus # $\bm{t}_k \gets \bm{A}\bm{z}_k - c_k\bm{p}_k \bmod q$
+
+		# Return #
+		return bool(np_sum(challenges) % self.__modulus == self.__hashScalar(checkedMessage, self.__publicKeys, commitments)) # $\textbf{return}\ b \gets [\sum_{k = 0}^{N - 1} c_k \bmod q = H_q(m, \bm{P}, \bm{T})]$
+	def Link(self:object) -> bool: # $\textbf{Link}(\sigma_1) \to b, b \in \{0, 1\}$
+		# Checks #
 		if self.__ringSignature is None:
 			return False
-		firstSignature = self.__ringSignature
-		secondSignature = self.Sign()
-		self.__linkedSignature = secondSignature
-		return bool(firstSignature[2] == secondSignature[2] and self.Verify(secondSignature, self.__message))
+
+		# Scheme #
+		firstSignature = self.__ringSignature # parse the current signature as $\sigma_1 = (\bm{c}_1, \bm{Z}_1, \eta_1)$
+		secondSignature = self.Sign() # generate a fresh message $m_2 \xleftarrow{\$} \{0, 1\}^{256}$ and compute $\sigma_2 \gets \textbf{Sign}(\bm{S}, \bm{P}, m_2)$
+		self.__linkedSignature = secondSignature # parse $\sigma_2 = (\bm{c}_2, \bm{Z}_2, \eta_2)$ and retain it as the linked signature
+
+		# Return #
+		return bool(firstSignature[2] == secondSignature[2] and self.Verify(secondSignature, self.__message)) # $\textbf{return}\ b \gets [\eta_1 = \eta_2] \land \textbf{Verify}(\bm{P}, m_2, \sigma_2)$
 	def getLengthOf(self:object, obj:object) -> int|str:
 		if isinstance(obj, ndarray):
 			return int(obj.nbytes)

--- a/SchemeFSMUAEKS/SchemeFSMUAEKS.py
+++ b/SchemeFSMUAEKS/SchemeFSMUAEKS.py
@@ -651,107 +651,136 @@ class SchemeFSMUAEKS:
 	def __hashMatrix(self:object, pkS:tuple, pkR:tuple, value:ndarray) -> ndarray:
 		message = concatenate((*pkS, *pkR, value), axis = 1)
 		return asarray(Matrix(self.__H1(message, self.__m)).inv()).astype("int") % self.__q
-	def Setup(self:object, n:int = __DefaultN, m:int = __DefaultM, q:int = __DefaultQ, lS:int = __DefaultLS, lR:int = __DefaultLR) -> tuple:
+	def Setup(self:object, n:int = __DefaultN, m:int = __DefaultM, q:int = __DefaultQ, lS:int = __DefaultLS, lR:int = __DefaultLR) -> tuple: # $\textbf{Setup}(n, m, q, \ell_S, \ell_R) \to \textit{pp}$
 		if not all(isinstance(value, int) and value >= 1 for value in (n, m, lS, lR)) or not isinstance(q, int) or q <= 1:
 			raise ValueError("The parameters n, m, q, lS, and lR must be positive integers, and q must be greater than one. ")
 		if m % (n << 1):
 			raise ValueError("The parameters n and m must satisfy 2n | m. ")
-		self.__n, self.__m, self.__q, self.__lS, self.__lR = n, m, q, lS, lR
-		self.__B = randint(q, size = (6, n, m))
-		self.__pkS, self.__skS, self.__pkR, self.__skR = (None, ) * 4
-		self.__Ft, self.__cipherText, self.__trapdoor = (None, ) * 3
-		return (n, m, q, lS, lR, self.__B)
-	def KeyGenS(self:object) -> tuple:
+
+		# Scheme #
+		self.__n, self.__m, self.__q, self.__lS, self.__lR = n, m, q, lS, lR # $(n, m, q, \ell_S, \ell_R) \gets (n, m, q, \ell_S, \ell_R)$
+		self.__B = randint(q, size = (6, n, m)) # generate $\bm{B}_0, \bm{B}_1, \ldots, \bm{B}_5 \in \mathbb{Z}_q^{n \times m}$ uniformly at random
+		self.__pkS, self.__skS, self.__pkR, self.__skR = (None, ) * 4 # $(\textit{pk}_S, \textit{sk}_S, \textit{pk}_R, \textit{sk}_R) \gets (\perp, \perp, \perp, \perp)$
+		self.__Ft, self.__cipherText, self.__trapdoor = (None, ) * 3 # $(\bm{F}_t, \textit{CT}, \textit{td}) \gets (\perp, \perp, \perp)$
+
+		# Return #
+		return (n, m, q, lS, lR, self.__B) # $\textbf{return}\ \textit{pp} \gets (n, m, q, \ell_S, \ell_R, (\bm{B}_i)_{i = 0}^{5})$
+	def KeyGenS(self:object) -> tuple: # $\textbf{KeyGenS}(\textit{pp}) \to (\textit{pk}_S, \textit{sk}_S)$
 		self.__requireSetup()
-		A, TA = self.__TrapGen()
-		US = randint(self.__q, size = (self.__n, self.__n))
-		DA = randint(self.__q, size = (self.__n, self.__m))
-		AW = randint(self.__q, size = (self.__n, self.__m))
-		self.__pkS, self.__skS = (A, US, DA, AW), TA
-		return (self.__pkS, self.__skS)
-	def KeyGenR(self:object) -> tuple:
+
+		# Scheme #
+		A, TA = self.__TrapGen() # $(\bm{A}, \bm{T}_A) \gets \textbf{TrapGen}(n, m, q)$
+		US = randint(self.__q, size = (self.__n, self.__n)) # generate $\bm{U}_S \in \mathbb{Z}_q^{n \times n}$ uniformly at random
+		DA = randint(self.__q, size = (self.__n, self.__m)) # generate $\bm{D}_A \in \mathbb{Z}_q^{n \times m}$ uniformly at random
+		AW = randint(self.__q, size = (self.__n, self.__m)) # generate $\bm{A}_W \in \mathbb{Z}_q^{n \times m}$ uniformly at random
+		self.__pkS, self.__skS = (A, US, DA, AW), TA # $(\textit{pk}_S, \textit{sk}_S) \gets ((\bm{A}, \bm{U}_S, \bm{D}_A, \bm{A}_W), \bm{T}_A)$
+
+		# Return #
+		return (self.__pkS, self.__skS) # $\textbf{return}\ (\textit{pk}_S, \textit{sk}_S)$
+	def KeyGenR(self:object) -> tuple: # $\textbf{KeyGenR}(\textit{pp}) \to (\textit{pk}_R, \textit{sk}_R)$
 		self.__requireSetup()
-		B0, TB0 = self.__TrapGen()
-		UR = randint(self.__q, size = (self.__n, self.__n))
-		DB = randint(self.__q, size = (self.__n, self.__m))
-		BW = randint(self.__q, size = (self.__n, self.__m))
-		self.__pkR, self.__skR = (B0, UR, DB, BW), TB0
-		return (self.__pkR, self.__skR)
-	def KeyUpdate(self:object) -> tuple:
+
+		# Scheme #
+		B0, TB0 = self.__TrapGen() # $(\bm{B}_0', \bm{T}_{B_0'}) \gets \textbf{TrapGen}(n, m, q)$
+		UR = randint(self.__q, size = (self.__n, self.__n)) # generate $\bm{U}_R \in \mathbb{Z}_q^{n \times n}$ uniformly at random
+		DB = randint(self.__q, size = (self.__n, self.__m)) # generate $\bm{D}_B \in \mathbb{Z}_q^{n \times m}$ uniformly at random
+		BW = randint(self.__q, size = (self.__n, self.__m)) # generate $\bm{B}_W \in \mathbb{Z}_q^{n \times m}$ uniformly at random
+		self.__pkR, self.__skR = (B0, UR, DB, BW), TB0 # $(\textit{pk}_R, \textit{sk}_R) \gets ((\bm{B}_0', \bm{U}_R, \bm{D}_B, \bm{B}_W), \bm{T}_{B_0'})$
+
+		# Return #
+		return (self.__pkR, self.__skR) # $\textbf{return}\ (\textit{pk}_R, \textit{sk}_R)$
+	def KeyUpdate(self:object) -> tuple: # $\textbf{KeyUpdate}(\textit{pp}, \textit{pk}_R, \textit{sk}_R) \to (\textit{fsk}_t, \bm{F}_t)$
 		self.__requireSetup()
 		if self.__pkR is None or self.__skR is None:
 			raise RuntimeError("The receiver keys have not been generated. ")
-		B0, B, q = self.__pkR[0], self.__B, self.__q
-		F001 = concatenate((B0, B[0], B[2], B[5]), axis = 1)
-		F01 = concatenate((B0, B[0], B[3]), axis = 1)
-		F1 = concatenate((B0, B[1]), axis = 1)
-		F011 = concatenate((B0, B[0], B[3], B[5]), axis = 1)
-		F101 = concatenate((B0, B[1], B[2], B[5]), axis = 1)
-		F11 = concatenate((B0, B[1], B[3]), axis = 1)
-		F111 = concatenate((B0, B[1], B[3], B[5]), axis = 1)
-		F = (F001, F01, F1, F011, F101, F11, F111)
-		T001 = self.__ExtBasis(F001, self.__skR, B0, q)
-		T01 = self.__ExtBasis(F01, self.__skR, B0, q)
-		T1 = self.__ExtBasis(F1, self.__skR, B0, q)
-		T011 = self.__ExtBasis(F011, self.__skR, B0, q)
-		T101 = self.__ExtBasis(F101, self.__skR, B0, q)
-		T11 = self.__ExtBasis(F11, self.__skR, B0, q)
-		T111 = self.__ExtBasis(F111, self.__skR, B0, q)
-		forwardSecretKeys = ((T001, T01, T1), (T01, T1), (T011, T1), (T1, ), (T101, T11), (T11, ), (T111, ))
-		index = randint(len(F))
-		self.__Ft = F[index]
-		return (forwardSecretKeys[index], self.__Ft)
-	def Encryption(self:object) -> tuple:
+
+		# Scheme #
+		B0, B, q = self.__pkR[0], self.__B, self.__q # $(\bm{B}_0', (\bm{B}_i)_{i = 0}^{5}, q) \gets (\textit{pk}_R[0], \textit{pp}.\bm{B}, \textit{pp}.q)$
+		F001 = concatenate((B0, B[0], B[2], B[5]), axis = 1) # $\bm{F}_{001} \gets [\bm{B}_0' \mid \bm{B}_0 \mid \bm{B}_2 \mid \bm{B}_5]$
+		F01 = concatenate((B0, B[0], B[3]), axis = 1) # $\bm{F}_{01} \gets [\bm{B}_0' \mid \bm{B}_0 \mid \bm{B}_3]$
+		F1 = concatenate((B0, B[1]), axis = 1) # $\bm{F}_{1} \gets [\bm{B}_0' \mid \bm{B}_1]$
+		F011 = concatenate((B0, B[0], B[3], B[5]), axis = 1) # $\bm{F}_{011} \gets [\bm{B}_0' \mid \bm{B}_0 \mid \bm{B}_3 \mid \bm{B}_5]$
+		F101 = concatenate((B0, B[1], B[2], B[5]), axis = 1) # $\bm{F}_{101} \gets [\bm{B}_0' \mid \bm{B}_1 \mid \bm{B}_2 \mid \bm{B}_5]$
+		F11 = concatenate((B0, B[1], B[3]), axis = 1) # $\bm{F}_{11} \gets [\bm{B}_0' \mid \bm{B}_1 \mid \bm{B}_3]$
+		F111 = concatenate((B0, B[1], B[3], B[5]), axis = 1) # $\bm{F}_{111} \gets [\bm{B}_0' \mid \bm{B}_1 \mid \bm{B}_3 \mid \bm{B}_5]$
+		F = (F001, F01, F1, F011, F101, F11, F111) # $\mathcal{F} \gets (\bm{F}_{001}, \bm{F}_{01}, \bm{F}_{1}, \bm{F}_{011}, \bm{F}_{101}, \bm{F}_{11}, \bm{F}_{111})$
+		T001 = self.__ExtBasis(F001, self.__skR, B0, q) # $\bm{T}_{001} \gets \textbf{ExtBasis}(\bm{F}_{001}, \bm{T}_{B_0'}, \bm{B}_0', q)$
+		T01 = self.__ExtBasis(F01, self.__skR, B0, q) # $\bm{T}_{01} \gets \textbf{ExtBasis}(\bm{F}_{01}, \bm{T}_{B_0'}, \bm{B}_0', q)$
+		T1 = self.__ExtBasis(F1, self.__skR, B0, q) # $\bm{T}_{1} \gets \textbf{ExtBasis}(\bm{F}_{1}, \bm{T}_{B_0'}, \bm{B}_0', q)$
+		T011 = self.__ExtBasis(F011, self.__skR, B0, q) # $\bm{T}_{011} \gets \textbf{ExtBasis}(\bm{F}_{011}, \bm{T}_{B_0'}, \bm{B}_0', q)$
+		T101 = self.__ExtBasis(F101, self.__skR, B0, q) # $\bm{T}_{101} \gets \textbf{ExtBasis}(\bm{F}_{101}, \bm{T}_{B_0'}, \bm{B}_0', q)$
+		T11 = self.__ExtBasis(F11, self.__skR, B0, q) # $\bm{T}_{11} \gets \textbf{ExtBasis}(\bm{F}_{11}, \bm{T}_{B_0'}, \bm{B}_0', q)$
+		T111 = self.__ExtBasis(F111, self.__skR, B0, q) # $\bm{T}_{111} \gets \textbf{ExtBasis}(\bm{F}_{111}, \bm{T}_{B_0'}, \bm{B}_0', q)$
+		forwardSecretKeys = ((T001, T01, T1), (T01, T1), (T011, T1), (T1, ), (T101, T11), (T11, ), (T111, )) # $(\textit{fsk}_{001}, \textit{fsk}_{01}, \textit{fsk}_{1}, \textit{fsk}_{011}, \textit{fsk}_{101}, \textit{fsk}_{11}, \textit{fsk}_{111}) \gets ((\bm{T}_{001}, \bm{T}_{01}, \bm{T}_{1}), (\bm{T}_{01}, \bm{T}_{1}), (\bm{T}_{011}, \bm{T}_{1}), (\bm{T}_{1}), (\bm{T}_{101}, \bm{T}_{11}), (\bm{T}_{11}), (\bm{T}_{111}))$
+		index = randint(len(F)) # generate $t \in \{001, 01, 1, 011, 101, 11, 111\}$ uniformly at random
+		self.__Ft = F[index] # $\bm{F}_t \gets \mathcal{F}[t]$
+
+		# Return #
+		return (forwardSecretKeys[index], self.__Ft) # $\textbf{return}\ (\textit{fsk}_t, \bm{F}_t)$
+	def Encryption(self:object) -> tuple: # $\textbf{Encryption}(\textit{pp}, \textit{pk}_S, \textit{pk}_R, \bm{F}_t) \to \textit{CT}$
 		self.__requireSetup()
 		if any(value is None for value in (self.__pkS, self.__skS, self.__pkR, self.__Ft)):
 			raise RuntimeError("The sender keys, receiver keys, and forward key must be generated before encryption. ")
-		n, m, q, lS = self.__n, self.__m, self.__q, self.__lS
-		A, US, DA, AW = self.__pkS
-		DB, BW = self.__pkR[2], self.__pkR[3]
-		EW, SS, ck = randint(q, size = (m, lS)), randint(q, size = (n, lS)), randint(q, size = (n, 1))
-		hashMatrix = self.__hashMatrix(self.__pkS, self.__pkR, ck)
-		Cw = (EW + dot((dot(AW, hashMatrix) % q).T, SS) % q) % q
-		RA = (randint(2, size = (m, m)) << 1) - 1
-		RC = (randint(2, size = (m, m)) << 1) - 1
-		Ca = (dot(A.T, SS) % q + dot(RA, EW) % q) % q
-		Cc = (dot(DA.T, SS) % q + dot(RC, EW) % q) % q
-		RB = (randint(2, size = (self.__Ft.shape[1], m)) << 1) - 1
-		EU = randint(q, size = (n, lS))
-		Cb = (dot(self.__Ft.T, SS) % q + dot(RB, EW) % q) % q
-		Cu = (dot(US, SS) % q + EU) % q
-		ES = self.__SampleLeft(A, Cu, q)
-		self.__cipherText = (Cw, Ca, Cb, Cc, ES)
-		return self.__cipherText
-	def Trapdoor(self:object) -> tuple:
+
+		# Scheme #
+		n, m, q, lS = self.__n, self.__m, self.__q, self.__lS # $(n, m, q, \ell_S) \gets \textit{pp}.(n, m, q, \ell_S)$
+		A, US, DA, AW = self.__pkS # $(\bm{A}, \bm{U}_S, \bm{D}_A, \bm{A}_W) \gets \textit{pk}_S$
+		DB, BW = self.__pkR[2], self.__pkR[3] # $(\bm{D}_B, \bm{B}_W) \gets (\textit{pk}_R[2], \textit{pk}_R[3])$
+		EW, SS, ck = randint(q, size = (m, lS)), randint(q, size = (n, lS)), randint(q, size = (n, 1)) # generate $\bm{E}_W \in \mathbb{Z}_q^{m \times \ell_S}$, $\bm{S}_S \in \mathbb{Z}_q^{n \times \ell_S}$, and $\textit{ck} \in \mathbb{Z}_q^{n \times 1}$ uniformly at random
+		hashMatrix = self.__hashMatrix(self.__pkS, self.__pkR, ck) # $\bm{H}_{\textit{ck}} \gets H_1(\textit{pk}_S \Vert \textit{pk}_R \Vert \textit{ck})^{-1} \bmod q$
+		Cw = (EW + dot((dot(AW, hashMatrix) % q).T, SS) % q) % q # $\bm{C}_w \gets \bm{E}_W + (\bm{A}_W \bm{H}_{\textit{ck}})^{\mathsf{T}} \bm{S}_S \bmod q$
+		RA = (randint(2, size = (m, m)) << 1) - 1 # generate $\bm{R}_A \in \{-1, 1\}^{m \times m}$ uniformly at random
+		RC = (randint(2, size = (m, m)) << 1) - 1 # generate $\bm{R}_C \in \{-1, 1\}^{m \times m}$ uniformly at random
+		Ca = (dot(A.T, SS) % q + dot(RA, EW) % q) % q # $\bm{C}_a \gets \bm{A}^{\mathsf{T}} \bm{S}_S + \bm{R}_A \bm{E}_W \bmod q$
+		Cc = (dot(DA.T, SS) % q + dot(RC, EW) % q) % q # $\bm{C}_c \gets \bm{D}_A^{\mathsf{T}} \bm{S}_S + \bm{R}_C \bm{E}_W \bmod q$
+		RB = (randint(2, size = (self.__Ft.shape[1], m)) << 1) - 1 # generate $\bm{R}_B \in \{-1, 1\}^{\operatorname{cols}(\bm{F}_t) \times m}$ uniformly at random
+		EU = randint(q, size = (n, lS)) # generate $\bm{E}_U \in \mathbb{Z}_q^{n \times \ell_S}$ uniformly at random
+		Cb = (dot(self.__Ft.T, SS) % q + dot(RB, EW) % q) % q # $\bm{C}_b \gets \bm{F}_t^{\mathsf{T}} \bm{S}_S + \bm{R}_B \bm{E}_W \bmod q$
+		Cu = (dot(US, SS) % q + EU) % q # $\bm{C}_u \gets \bm{U}_S \bm{S}_S + \bm{E}_U \bmod q$
+		ES = self.__SampleLeft(A, Cu, q) # $\bm{E}_S \gets \textbf{SampleLeft}(\bm{A}, \bm{C}_u, q)$ such that $\bm{A}\bm{E}_S = \bm{C}_u \bmod q$
+		self.__cipherText = (Cw, Ca, Cb, Cc, ES) # $\textit{CT} \gets (\bm{C}_w, \bm{C}_a, \bm{C}_b, \bm{C}_c, \bm{E}_S)$
+
+		# Return #
+		return self.__cipherText # $\textbf{return}\ \textit{CT}$
+	def Trapdoor(self:object) -> tuple: # $\textbf{Trapdoor}(\textit{pp}, \textit{pk}_S, \textit{pk}_R, \textit{sk}_R, \bm{F}_t) \to \textit{td}$
 		self.__requireSetup()
 		if any(value is None for value in (self.__pkS, self.__pkR, self.__skR, self.__Ft)):
 			raise RuntimeError("The sender keys, receiver keys, and forward key must be generated before trapdoor generation. ")
-		n, m, q, lR = self.__n, self.__m, self.__q, self.__lR
-		A, US, DA, AW = self.__pkS
-		DB, BW = self.__pkR[2], self.__pkR[3]
-		SR, EDoubleW, tk = randint(q, size = (n, lR)), randint(q, size = (m, lR)), randint(q, size = (n, 1))
-		hashMatrix = self.__hashMatrix(self.__pkS, self.__pkR, tk)
-		Tw = (EDoubleW + dot((dot(BW, hashMatrix) % q).T, SR) % q) % q
-		RDoubleA = (randint(2, size = (m, m)) << 1) - 1
-		RDoubleB = (randint(2, size = (self.__Ft.shape[1], m)) << 1) - 1
-		RDoubleC = (randint(2, size = (m, m)) << 1) - 1
-		Ta = (dot(A.T, SR) % q + dot(RDoubleA, EDoubleW) % q) % q
-		Tb = (dot(self.__Ft.T, SR) % q + dot(RDoubleB, EDoubleW) % q) % q
-		Tc = (dot(DB.T, SR) % q + dot(RDoubleC, EDoubleW) % q) % q
-		EDoubleU = randint(q, size = (n, lR))
-		Tu = (dot(US, SR) % q + EDoubleU) % q
-		ER = self.__SampleLeft(self.__Ft, Tu, q)
-		self.__trapdoor = (Tw, Ta, Tb, Tc, ER)
-		return self.__trapdoor
-	def Test(self:object) -> bool:
+
+		# Scheme #
+		n, m, q, lR = self.__n, self.__m, self.__q, self.__lR # $(n, m, q, \ell_R) \gets \textit{pp}.(n, m, q, \ell_R)$
+		A, US, DA, AW = self.__pkS # $(\bm{A}, \bm{U}_S, \bm{D}_A, \bm{A}_W) \gets \textit{pk}_S$
+		DB, BW = self.__pkR[2], self.__pkR[3] # $(\bm{D}_B, \bm{B}_W) \gets (\textit{pk}_R[2], \textit{pk}_R[3])$
+		SR, EDoubleW, tk = randint(q, size = (n, lR)), randint(q, size = (m, lR)), randint(q, size = (n, 1)) # generate $\bm{S}_R \in \mathbb{Z}_q^{n \times \ell_R}$, $\bm{E}'_W \in \mathbb{Z}_q^{m \times \ell_R}$, and $\textit{tk} \in \mathbb{Z}_q^{n \times 1}$ uniformly at random
+		hashMatrix = self.__hashMatrix(self.__pkS, self.__pkR, tk) # $\bm{H}_{\textit{tk}} \gets H_1(\textit{pk}_S \Vert \textit{pk}_R \Vert \textit{tk})^{-1} \bmod q$
+		Tw = (EDoubleW + dot((dot(BW, hashMatrix) % q).T, SR) % q) % q # $\bm{T}_w \gets \bm{E}'_W + (\bm{B}_W \bm{H}_{\textit{tk}})^{\mathsf{T}} \bm{S}_R \bmod q$
+		RDoubleA = (randint(2, size = (m, m)) << 1) - 1 # generate $\bm{R}'_A \in \{-1, 1\}^{m \times m}$ uniformly at random
+		RDoubleB = (randint(2, size = (self.__Ft.shape[1], m)) << 1) - 1 # generate $\bm{R}'_B \in \{-1, 1\}^{\operatorname{cols}(\bm{F}_t) \times m}$ uniformly at random
+		RDoubleC = (randint(2, size = (m, m)) << 1) - 1 # generate $\bm{R}'_C \in \{-1, 1\}^{m \times m}$ uniformly at random
+		Ta = (dot(A.T, SR) % q + dot(RDoubleA, EDoubleW) % q) % q # $\bm{T}_a \gets \bm{A}^{\mathsf{T}} \bm{S}_R + \bm{R}'_A \bm{E}'_W \bmod q$
+		Tb = (dot(self.__Ft.T, SR) % q + dot(RDoubleB, EDoubleW) % q) % q # $\bm{T}_b \gets \bm{F}_t^{\mathsf{T}} \bm{S}_R + \bm{R}'_B \bm{E}'_W \bmod q$
+		Tc = (dot(DB.T, SR) % q + dot(RDoubleC, EDoubleW) % q) % q # $\bm{T}_c \gets \bm{D}_B^{\mathsf{T}} \bm{S}_R + \bm{R}'_C \bm{E}'_W \bmod q$
+		EDoubleU = randint(q, size = (n, lR)) # generate $\bm{E}'_U \in \mathbb{Z}_q^{n \times \ell_R}$ uniformly at random
+		Tu = (dot(US, SR) % q + EDoubleU) % q # $\bm{T}_u \gets \bm{U}_S \bm{S}_R + \bm{E}'_U \bmod q$
+		ER = self.__SampleLeft(self.__Ft, Tu, q) # $\bm{E}_R \gets \textbf{SampleLeft}(\bm{F}_t, \bm{T}_u, q)$ such that $\bm{F}_t\bm{E}_R = \bm{T}_u \bmod q$
+		self.__trapdoor = (Tw, Ta, Tb, Tc, ER) # $\textit{td} \gets (\bm{T}_w, \bm{T}_a, \bm{T}_b, \bm{T}_c, \bm{E}_R)$
+
+		# Return #
+		return self.__trapdoor # $\textbf{return}\ \textit{td}$
+	def Test(self:object) -> bool: # $\textbf{Test}(\textit{pp}, \textit{CT}, \textit{td}) \to y,\ y \in \{0, 1\}$
 		self.__requireSetup()
-		if self.__cipherText is None or self.__trapdoor is None:
-			return False
-		Cb, ES = self.__cipherText[2], self.__cipherText[4]
-		Ta, ER = self.__trapdoor[1], self.__trapdoor[4]
-		value = (dot(ER.T, Cb) % self.__q - dot(Ta.T, ES) % self.__q) % self.__q
-		centeredValue = minimum(value, self.__q - value)
-		return bool((centeredValue < self.__q >> 2).all())
+
+		# Scheme #
+		if self.__cipherText is None or self.__trapdoor is None: # $\textbf{if}\ \textit{CT} = \perp \lor \textit{td} = \perp\ \textbf{then}$
+			return False # $\quad \textbf{return}\ 0$
+		# $\textbf{end if}$
+		Cb, ES = self.__cipherText[2], self.__cipherText[4] # $(\bm{C}_b, \bm{E}_S) \gets (\textit{CT}[2], \textit{CT}[4])$
+		Ta, ER = self.__trapdoor[1], self.__trapdoor[4] # $(\bm{T}_a, \bm{E}_R) \gets (\textit{td}[1], \textit{td}[4])$
+		value = (dot(ER.T, Cb) % self.__q - dot(Ta.T, ES) % self.__q) % self.__q # $\bm{V} \gets \bm{E}_R^{\mathsf{T}}\bm{C}_b - \bm{T}_a^{\mathsf{T}}\bm{E}_S \bmod q$
+		centeredValue = minimum(value, self.__q - value) # $\overline{\bm{V}} \gets \min(\bm{V}, q - \bm{V})$ component-wise
+
+		# Return #
+		return bool((centeredValue < self.__q >> 2).all()) # $\textbf{return}\ \bigwedge_{i,j} [\overline{V}_{i,j} < \lfloor q / 4 \rfloor]$
 	def getLengthOf(self:object, obj:object) -> int|str:
 		if isinstance(obj, ndarray):
 			return int(obj.nbytes)

--- a/SchemeLBPEAKS/SchemeLBPEAKS.py
+++ b/SchemeLBPEAKS/SchemeLBPEAKS.py
@@ -666,85 +666,113 @@ class SchemeLBPEAKS:
 		return total % self.__q
 	def __F(self:object, secretKey:ndarray, keywordSetU:ndarray, keywordSetW:ndarray, message:ndarray) -> ndarray:
 		return (self.__f1(secretKey, keywordSetU, message) - self.__f1(secretKey, keywordSetW, message)) % self.__q
-	def Setup(self:object, n:int = __DefaultN, m:int = __DefaultM, q:int = __DefaultQ) -> tuple:
+	def Setup(self:object, n:int = __DefaultN, m:int = __DefaultM, q:int = __DefaultQ) -> tuple: # $\textbf{Setup}(n, m, q) \to \textit{pp}$
 		if not all(isinstance(value, int) and value > 1 for value in (n, m, q)):
 			raise ValueError("The parameters n, m, and q must be integers greater than one. ")
 		if m % (n << 1):
 			raise ValueError("The parameters n and m must satisfy 2n | m. ")
-		self.__n, self.__m, self.__q = n, m, q
-		for _ in range(32):
-			A, TA = self.__TrapGen()
-			try:
-				Matrix(dot(A, A.T)).inv_mod(q)
-				break
-			except:
-				A, TA = None, None
-		if A is None or TA is None:
-			raise RuntimeError("Failed to generate an invertible lattice basis. ")
-		self.__A, self.__TA = A, TA
-		self.__B = randint(q, size = (n, m << 1))
-		self.__k = randint(self.__RandomLowerBound, min(m, self.__RandomUpperBound))
-		self.__keyword = randint(2, size = (self.__k, 1))
-		self.__U = randint(q, size = (n, self.__k))
-		self.__matrixVector = randint(q, size = (self.__k, n, m << 1))
-		self.__identity, self.__secretKey, self.__authorizedKey, self.__y = (None, ) * 4
-		self.__signature, self.__cipherText, self.__trapdoor = (None, ) * 3
-		return (A, self.__B, self.__U, self.__matrixVector, self.__keyword)
-	def KeyGen(self:object) -> tuple:
+
+		# Scheme #
+		self.__n, self.__m, self.__q = n, m, q # $(n, m, q) \gets (n, m, q)$
+		for _ in range(32): # $\textbf{repeat}\ \text{at most } 32 \text{ times}$
+			A, TA = self.__TrapGen() # $\quad (\bm{A}, \bm{T}_A) \gets \textbf{TrapGen}(n, m, q)$
+			try: # $\quad \textbf{if}\ \bm{A}\bm{A}^{\mathsf{T}} \text{ is invertible over } \mathbb{Z}_q\ \textbf{then}$
+				Matrix(dot(A, A.T)).inv_mod(q) # $\qquad \bm{Q} \gets (\bm{A}\bm{A}^{\mathsf{T}})^{-1} \bmod q$
+				break # $\qquad \textbf{break}$
+			except: # $\quad \textbf{else}$
+				A, TA = None, None # $\qquad (\bm{A}, \bm{T}_A) \gets (\perp, \perp)$
+			# $\quad \textbf{end if}$
+		# $\textbf{end repeat}$
+		if A is None or TA is None: # $\textbf{if}\ (\bm{A}, \bm{T}_A) = (\perp, \perp)\ \textbf{then}$
+			raise RuntimeError("Failed to generate an invertible lattice basis. ") # $\quad \textbf{return}\ \perp$
+		# $\textbf{end if}$
+		self.__A, self.__TA = A, TA # $(\bm{A}, \bm{T}_A) \gets (\bm{A}, \bm{T}_A)$
+		self.__B = randint(q, size = (n, m << 1)) # generate $\bm{B} \in \mathbb{Z}_q^{n \times 2m}$ uniformly at random
+		self.__k = randint(self.__RandomLowerBound, min(m, self.__RandomUpperBound)) # generate $k \in \{1, 2, \ldots, \min(m, 16) - 1\}$ uniformly at random
+		self.__keyword = randint(2, size = (self.__k, 1)) # generate the keyword $\bm{w} \in \{0, 1\}^{k \times 1}$ uniformly at random
+		self.__U = randint(q, size = (n, self.__k)) # generate $\bm{U} \in \mathbb{Z}_q^{n \times k}$ uniformly at random
+		self.__matrixVector = randint(q, size = (self.__k, n, m << 1)) # generate $(\bm{M}_i)_{i = 1}^{k}$ with $\bm{M}_i \in \mathbb{Z}_q^{n \times 2m}$ uniformly at random
+		self.__identity, self.__secretKey, self.__authorizedKey, self.__y = (None, ) * 4 # $(\textit{id}, \textit{sk}_{\textit{id}}, \textit{ak}, \bm{y}) \gets (\perp, \perp, \perp, \perp)$
+		self.__signature, self.__cipherText, self.__trapdoor = (None, ) * 3 # $(\sigma, \textit{CT}, \textit{td}) \gets (\perp, \perp, \perp)$
+
+		# Return #
+		return (A, self.__B, self.__U, self.__matrixVector, self.__keyword) # $\textbf{return}\ \textit{pp} \gets (\bm{A}, \bm{B}, \bm{U}, (\bm{M}_i)_{i = 1}^{k}, \bm{w})$
+	def KeyGen(self:object) -> tuple: # $\textbf{KeyGen}(\textit{pp}) \to (\textit{id}, \textit{sk}_{\textit{id}})$
 		self.__requireSetup()
-		length = randint(self.__RandomLowerBound, min(self.__n, self.__RandomUpperBound))
-		self.__identity = (randint(2, size = (length, 1)) << 1) - 1
-		self.__secretKey = self.__SamplePre(self.__A, self.__H1(self.__identity))
-		return (self.__identity, self.__secretKey)
-	def Authorize(self:object) -> tuple:
+
+		# Scheme #
+		length = randint(self.__RandomLowerBound, min(self.__n, self.__RandomUpperBound)) # generate $d_{\textit{id}} \in \{1, 2, \ldots, \min(n, 16) - 1\}$ uniformly at random
+		self.__identity = (randint(2, size = (length, 1)) << 1) - 1 # generate $\textit{id} \in \{-1, 1\}^{d_{\textit{id}} \times 1}$ uniformly at random
+		self.__secretKey = self.__SamplePre(self.__A, self.__H1(self.__identity)) # $\textit{sk}_{\textit{id}} \gets \textbf{SamplePre}(\bm{A}, H_1(\textit{id}))$ such that $\bm{A}\textit{sk}_{\textit{id}} = H_1(\textit{id}) \bmod q$
+
+		# Return #
+		return (self.__identity, self.__secretKey) # $\textbf{return}\ (\textit{id}, \textit{sk}_{\textit{id}})$
+	def Authorize(self:object) -> tuple: # $\textbf{Authorize}(\textit{pp}, \textit{sk}_{\textit{id}}) \to (\textit{ak}, \sigma, \bm{y})$
 		self.__requireSetup()
 		if self.__secretKey is None:
 			raise RuntimeError("The identity secret key has not been generated. ")
-		keywordSetW = randint(2, size = (randint(self.__RandomLowerBound, self.__RandomUpperBound), self.__k))
-		keywordSetU = concatenate((keywordSetW, randint(2, size = (randint(self.__RandomLowerBound, self.__RandomUpperBound), self.__k))), axis = 0)
-		message = concatenate((randint(2, size = (self.__k, 1)), randint(2, size = (randint(self.__RandomLowerBound, self.__RandomUpperBound), 1))), axis = 0)
-		self.__authorizedKey = self.__H3(self.__F(self.__secretKey, keywordSetU, keywordSetW, message))
-		self.__y = randint(self.__q, size = (self.__m, 1))
-		h = self.__H2(concatenate((dot(self.__A, self.__y) % self.__q, dot(self.__authorizedKey, self.__y) % self.__q), axis = 0))
-		z = (self.__secretKey * h % self.__q + self.__y) % self.__q
-		self.__signature = (h, z)
-		return (self.__authorizedKey, self.__signature, self.__y)
-	def Encrypt(self:object) -> tuple:
+
+		# Scheme #
+		keywordSetW = randint(2, size = (randint(self.__RandomLowerBound, self.__RandomUpperBound), self.__k)) # generate $W \subseteq \{0, 1\}^{k}$ with $1 \leq |W| \leq 15$ uniformly at random
+		keywordSetU = concatenate((keywordSetW, randint(2, size = (randint(self.__RandomLowerBound, self.__RandomUpperBound), self.__k))), axis = 0) # generate $U \gets W \Vert W'$ where $W' \subseteq \{0, 1\}^{k}$ and $1 \leq |W'| \leq 15$ uniformly at random
+		message = concatenate((randint(2, size = (self.__k, 1)), randint(2, size = (randint(self.__RandomLowerBound, self.__RandomUpperBound), 1))), axis = 0) # generate $\bm{\mu} \in \{0, 1\}^{k + d_{\mu}}$ with $1 \leq d_{\mu} \leq 15$ uniformly at random
+		self.__authorizedKey = self.__H3(self.__F(self.__secretKey, keywordSetU, keywordSetW, message)) # $\textit{ak} \gets H_3(F(\textit{sk}_{\textit{id}}, U, W, \bm{\mu}))$
+		self.__y = randint(self.__q, size = (self.__m, 1)) # generate $\bm{y} \in \mathbb{Z}_q^{m \times 1}$ uniformly at random
+		h = self.__H2(concatenate((dot(self.__A, self.__y) % self.__q, dot(self.__authorizedKey, self.__y) % self.__q), axis = 0)) # $h \gets H_2(\bm{A}\bm{y} \Vert \textit{ak}\bm{y})$
+		z = (self.__secretKey * h % self.__q + self.__y) % self.__q # $\bm{z} \gets h \cdot \textit{sk}_{\textit{id}} + \bm{y} \bmod q$
+		self.__signature = (h, z) # $\sigma \gets (h, \bm{z})$
+
+		# Return #
+		return (self.__authorizedKey, self.__signature, self.__y) # $\textbf{return}\ (\textit{ak}, \sigma, \bm{y})$
+	def Encrypt(self:object) -> tuple: # $\textbf{Encrypt}(\textit{pp}, \textit{id}, \bm{w}) \to \textit{CT}$
 		self.__requireSetup()
 		if self.__identity is None:
 			raise RuntimeError("The identity has not been generated. ")
-		q, m = self.__q, self.__m
-		AKeyword = (np_sum(self.__keyword[:, :, None] * self.__matrixVector, axis = 0) % q + self.__B) % q
-		AIdentity = concatenate((self.__A, self.__H4(self.__identity)), axis = 1)
-		AIdentityKeyword = concatenate((AIdentity, AKeyword), axis = 1)
-		R = (randint(2, size = (self.__k, m << 1, m << 1)) << 1) - 1
-		RKeyword = np_sum(self.__keyword[:, :, None] * R, axis = 0) % q
-		noise, noiseVector, randomVector = randint(q), randint(q, size = (m << 1, 1)), randint(q, size = (self.__n, 1))
-		c0 = (dot(self.__U.T, randomVector) % q + noise) % q
-		c1 = (dot(AIdentityKeyword.T, randomVector) % q + concatenate((noiseVector, dot(RKeyword.T, noiseVector) % q), axis = 0)) % q
-		self.__cipherText = (c0, c1)
-		return self.__cipherText
-	def Trapdoor(self:object) -> tuple:
+
+		# Scheme #
+		q, m = self.__q, self.__m # $(q, m) \gets \textit{pp}.(q, m)$
+		AKeyword = (np_sum(self.__keyword[:, :, None] * self.__matrixVector, axis = 0) % q + self.__B) % q # $\bm{A}_{\bm{w}} \gets \bm{B} + \sum_{i = 1}^{k} w_i \bm{M}_i \bmod q$
+		AIdentity = concatenate((self.__A, self.__H4(self.__identity)), axis = 1) # $\bm{A}_{\textit{id}} \gets [\bm{A} \mid H_4(\textit{id})]$
+		AIdentityKeyword = concatenate((AIdentity, AKeyword), axis = 1) # $\bm{A}_{\textit{id}, \bm{w}} \gets [\bm{A}_{\textit{id}} \mid \bm{A}_{\bm{w}}]$
+		R = (randint(2, size = (self.__k, m << 1, m << 1)) << 1) - 1 # generate $(\bm{R}_i)_{i = 1}^{k}$ with $\bm{R}_i \in \{-1, 1\}^{2m \times 2m}$ uniformly at random
+		RKeyword = np_sum(self.__keyword[:, :, None] * R, axis = 0) % q # $\bm{R}_{\bm{w}} \gets \sum_{i = 1}^{k} w_i \bm{R}_i \bmod q$
+		noise, noiseVector, randomVector = randint(q), randint(q, size = (m << 1, 1)), randint(q, size = (self.__n, 1)) # generate $e \in \mathbb{Z}_q$, $\bm{e} \in \mathbb{Z}_q^{2m \times 1}$, and $\bm{s} \in \mathbb{Z}_q^{n \times 1}$ uniformly at random
+		c0 = (dot(self.__U.T, randomVector) % q + noise) % q # $\bm{c}_0 \gets \bm{U}^{\mathsf{T}}\bm{s} + e\bm{1}_k \bmod q$
+		c1 = (dot(AIdentityKeyword.T, randomVector) % q + concatenate((noiseVector, dot(RKeyword.T, noiseVector) % q), axis = 0)) % q # $\bm{c}_1 \gets \bm{A}_{\textit{id}, \bm{w}}^{\mathsf{T}}\bm{s} + [\bm{e}^{\mathsf{T}} \mid (\bm{R}_{\bm{w}}^{\mathsf{T}}\bm{e})^{\mathsf{T}}]^{\mathsf{T}} \bmod q$
+		self.__cipherText = (c0, c1) # $\textit{CT} \gets (\bm{c}_0, \bm{c}_1)$
+
+		# Return #
+		return self.__cipherText # $\textbf{return}\ \textit{CT}$
+	def Trapdoor(self:object) -> tuple: # $\textbf{Trapdoor}(\textit{pp}, \textit{id}, \textit{ak}, \sigma, \bm{y}) \to \textit{td}$
 		self.__requireSetup()
 		if any(value is None for value in (self.__identity, self.__authorizedKey, self.__y, self.__signature)):
 			raise RuntimeError("Authorization has not been completed. ")
-		q, m = self.__q, self.__m
-		AKeyword = (np_sum(self.__keyword[:, :, None] * self.__matrixVector, axis = 0) % q + self.__B) % q
-		AIdentity = concatenate((self.__A, self.__H4(self.__identity)), axis = 1) % q
-		trap1 = dot(self.__authorizedKey, self.__y) % q
-		trap2 = randint(q, size = (m << 2, 1))
-		self.__trapdoor = (trap1, trap2, self.__signature, AIdentity, AKeyword)
-		return self.__trapdoor
-	def Test(self:object) -> bool:
+
+		# Scheme #
+		q, m = self.__q, self.__m # $(q, m) \gets \textit{pp}.(q, m)$
+		AKeyword = (np_sum(self.__keyword[:, :, None] * self.__matrixVector, axis = 0) % q + self.__B) % q # $\bm{A}_{\bm{w}} \gets \bm{B} + \sum_{i = 1}^{k} w_i \bm{M}_i \bmod q$
+		AIdentity = concatenate((self.__A, self.__H4(self.__identity)), axis = 1) % q # $\bm{A}_{\textit{id}} \gets [\bm{A} \mid H_4(\textit{id})] \bmod q$
+		trap1 = dot(self.__authorizedKey, self.__y) % q # $\bm{t}_1 \gets \textit{ak}\bm{y} \bmod q$
+		trap2 = randint(q, size = (m << 2, 1)) # generate $\bm{t}_2 \in \mathbb{Z}_q^{4m \times 1}$ uniformly at random
+		self.__trapdoor = (trap1, trap2, self.__signature, AIdentity, AKeyword) # $\textit{td} \gets (\bm{t}_1, \bm{t}_2, \sigma, \bm{A}_{\textit{id}}, \bm{A}_{\bm{w}})$
+
+		# Return #
+		return self.__trapdoor # $\textbf{return}\ \textit{td}$
+	def Test(self:object) -> bool: # $\textbf{Test}(\textit{pp}, \textit{id}, \textit{CT}, \textit{td}) \to y,\ y \in \{0, 1\}$
 		self.__requireSetup()
-		if self.__cipherText is None or self.__trapdoor is None:
-			return False
-		c0, c1 = self.__cipherText
-		trap1, trap2, signature = self.__trapdoor[:3]
-		h, z = signature
-		verified = h == self.__H2(concatenate(((dot(self.__A, z) - self.__H1(self.__identity) * h % self.__q) % self.__q, trap1), axis = 0))
-		rankVerified = matrix_rank((c0 - dot(trap2.T, c1) % self.__q) % self.__q) <= self.__q >> 2
-		return bool(verified and rankVerified)
+
+		# Scheme #
+		if self.__cipherText is None or self.__trapdoor is None: # $\textbf{if}\ \textit{CT} = \perp \lor \textit{td} = \perp\ \textbf{then}$
+			return False # $\quad \textbf{return}\ 0$
+		# $\textbf{end if}$
+		c0, c1 = self.__cipherText # $(\bm{c}_0, \bm{c}_1) \gets \textit{CT}$
+		trap1, trap2, signature = self.__trapdoor[:3] # $(\bm{t}_1, \bm{t}_2, \sigma) \gets (\textit{td}[0], \textit{td}[1], \textit{td}[2])$
+		h, z = signature # $(h, \bm{z}) \gets \sigma$
+		verified = h == self.__H2(concatenate(((dot(self.__A, z) - self.__H1(self.__identity) * h % self.__q) % self.__q, trap1), axis = 0)) # $b_1 \gets [h = H_2((\bm{A}\bm{z} - hH_1(\textit{id}) \bmod q) \Vert \bm{t}_1)]$
+		rankVerified = matrix_rank((c0 - dot(trap2.T, c1) % self.__q) % self.__q) <= self.__q >> 2 # $b_2 \gets [\operatorname{rank}(\bm{c}_0 - \bm{t}_2^{\mathsf{T}}\bm{c}_1 \bmod q) \leq \lfloor q / 4 \rfloor]$
+
+		# Return #
+		return bool(verified and rankVerified) # $\textbf{return}\ b_1 \land b_2$
 	def getLengthOf(self:object, obj:object) -> int|str:
 		if isinstance(obj, ndarray):
 			return int(obj.nbytes)

--- a/SchemeLWEPEKS/SchemeLWEPEKS.py
+++ b/SchemeLWEPEKS/SchemeLWEPEKS.py
@@ -613,61 +613,86 @@ class SchemeLWEPEKS:
 			raise RuntimeError("The scheme has not been set up. ")
 	def __randomSigned(self:object, shape:tuple) -> ndarray:
 		return randint(-self.__q, self.__q + 1, size = shape)
-	def Setup(self:object, n:int, m:int, q:int) -> tuple:
+	def Setup(self:object, n:int, m:int, q:int) -> tuple: # $\textbf{Setup}(n, m, q) \to (\bm{A}, \bm{T}_A)$
+		# Checks #
 		if not all(isinstance(value, int) and value > 1 for value in (n, m, q)):
 			raise ValueError("The parameters n, m, and q must be integers greater than one. ")
 		if m % n:
 			raise ValueError("The parameters n and m must satisfy n | m. ")
-		self.__n, self.__m, self.__q = n, m, q
-		self.__keywordLength, self.__identityLength = min(4, m), min(4, m)
-		self.__publicMatrix = randint(q, size = (n, m))
-		reversedMatrix = self.__publicMatrix[:, ::-1]
-		self.__masterSecretKey = concatenate((reversedMatrix.T, q * eye(m, dtype = "int")), axis = 1)
-		self.__derivedPublicMatrix, self.__derivedSecretKey = None, None
-		self.__keyword, self.__cipherText, self.__searchTrapdoor = None, None, None
-		return (self.__publicMatrix, self.__masterSecretKey)
-	def Derive(self:object) -> tuple:
+
+		# Scheme #
+		self.__n, self.__m, self.__q = n, m, q # set the lattice parameters $(n, m, q)$, where $n \mid m$
+		self.__keywordLength, self.__identityLength = min(4, m), min(4, m) # set $\ell_W \gets \min\{4, m\}$ and $\ell_I \gets \min\{4, m\}$
+		self.__publicMatrix = randint(q, size = (n, m)) # generate $\bm{A} \xleftarrow{\$} \mathbb{Z}_q^{n \times m}$
+		reversedMatrix = self.__publicMatrix[:, ::-1] # let $\bm{A}^{\mathsf{rev}}$ be $\bm{A}$ with its columns in reverse order
+		self.__masterSecretKey = concatenate((reversedMatrix.T, q * eye(m, dtype = "int")), axis = 1) # $\bm{T}_A \gets [ (\bm{A}^{\mathsf{rev}})^\mathsf{T} \mid q\bm{I}_m ] \in \mathbb{Z}^{m \times (n + m)}$
+		self.__derivedPublicMatrix, self.__derivedSecretKey = None, None # initialize the derived public and secret keys as undefined
+		self.__keyword, self.__cipherText, self.__searchTrapdoor = None, None, None # initialize the keyword, ciphertext, and search trapdoor as undefined
+
+		# Return #
+		return (self.__publicMatrix, self.__masterSecretKey) # $\textbf{return}\ (\bm{A}, \bm{T}_A)$
+	def Derive(self:object) -> tuple: # $\textbf{Derive}(\bm{A}, \bm{T}_A) \to (\mathsf{id}, \bm{A}_{\mathsf{id}}, \bm{T}_{\mathsf{id}})$
+		# Checks #
 		self.__requireSetup()
-		identity = randint(2, size = (self.__identityLength, ))
-		identityMatrices = self.__randomSigned((self.__identityLength, self.__n, self.__m))
-		identityMatrix = np_sum(identity[:, None, None] * identityMatrices, axis = 0) % self.__q
-		self.__derivedPublicMatrix = concatenate((self.__publicMatrix, identityMatrix), axis = 1)
-		extension = randint(self.__q, size = (self.__m, self.__n))
-		self.__derivedSecretKey = concatenate((self.__masterSecretKey, extension), axis = 1)
-		return (identity, self.__derivedPublicMatrix, self.__derivedSecretKey)
-	def Encrypt(self:object) -> tuple:
+
+		# Scheme #
+		identity = randint(2, size = (self.__identityLength, )) # generate $\mathsf{id} \gets (\mathsf{id}_1, \ldots, \mathsf{id}_{\ell_I}) \xleftarrow{\$} \{0, 1\}^{\ell_I}$
+		identityMatrices = self.__randomSigned((self.__identityLength, self.__n, self.__m)) # generate $\bm{B}_j \xleftarrow{\$} \{-q, -q + 1, \ldots, q\}^{n \times m}$ for every $j \in \{1, \ldots, \ell_I\}$
+		identityMatrix = np_sum(identity[:, None, None] * identityMatrices, axis = 0) % self.__q # $\bm{B}_{\mathsf{id}} \gets \sum_{j = 1}^{\ell_I} \mathsf{id}_j\bm{B}_j \bmod q$
+		self.__derivedPublicMatrix = concatenate((self.__publicMatrix, identityMatrix), axis = 1) # $\bm{A}_{\mathsf{id}} \gets [\bm{A} \mid \bm{B}_{\mathsf{id}}] \in \mathbb{Z}_q^{n \times 2m}$
+		extension = randint(self.__q, size = (self.__m, self.__n)) # generate $\bm{R} \xleftarrow{\$} \mathbb{Z}_q^{m \times n}$
+		self.__derivedSecretKey = concatenate((self.__masterSecretKey, extension), axis = 1) # $\bm{T}_{\mathsf{id}} \gets [\bm{T}_A \mid \bm{R}] \in \mathbb{Z}^{m \times (m + 2n)}$
+
+		# Return #
+		return (identity, self.__derivedPublicMatrix, self.__derivedSecretKey) # $\textbf{return}\ (\mathsf{id}, \bm{A}_{\mathsf{id}}, \bm{T}_{\mathsf{id}})$
+	def Encrypt(self:object) -> tuple: # $\textbf{Encrypt}(\bm{A}_{\mathsf{id}}) \to \textit{CT}_W$
+		# Checks #
 		self.__requireSetup()
 		if self.__derivedPublicMatrix is None:
 			raise RuntimeError("The identity key has not been derived. ")
-		self.__keyword = randint(2, size = (self.__keywordLength, ))
-		keywordMatrices = self.__randomSigned((self.__keywordLength, self.__n, self.__m))
-		keywordMatrix = np_sum(self.__keyword[:, None, None] * keywordMatrices, axis = 0) % self.__q
-		encryptionMatrix = concatenate((self.__derivedPublicMatrix, keywordMatrix), axis = 1)
-		randomVector = randint(self.__q, size = (self.__n, 1))
-		messageVector = randint(self.__q, size = (self.__n, 1))
-		noiseVector = randint(self.__q, size = (self.__m, 1))
-		randomSigns = randint(-1, 2, size = (self.__m << 1, self.__m))
-		noise = concatenate((noiseVector, dot(randomSigns, noiseVector)), axis = 0)
-		c1 = int(dot(messageVector.T, randomVector)[0, 0] % self.__q)
-		c2 = (dot(encryptionMatrix.T, randomVector) + noise) % self.__q
-		keywordHash = sha3_256(self.__keyword.astype("int64", copy = False).tobytes()).digest()
-		self.__cipherText = (c1, c2, keywordHash)
-		return self.__cipherText
-	def Trapdoor(self:object) -> tuple:
+
+		# Scheme #
+		self.__keyword = randint(2, size = (self.__keywordLength, )) # generate the keyword $W \gets (W_1, \ldots, W_{\ell_W}) \xleftarrow{\$} \{0, 1\}^{\ell_W}$
+		keywordMatrices = self.__randomSigned((self.__keywordLength, self.__n, self.__m)) # generate $\bm{C}_j \xleftarrow{\$} \{-q, -q + 1, \ldots, q\}^{n \times m}$ for every $j \in \{1, \ldots, \ell_W\}$
+		keywordMatrix = np_sum(self.__keyword[:, None, None] * keywordMatrices, axis = 0) % self.__q # $\bm{C}_W \gets \sum_{j = 1}^{\ell_W} W_j\bm{C}_j \bmod q$
+		encryptionMatrix = concatenate((self.__derivedPublicMatrix, keywordMatrix), axis = 1) # $\bm{E}_{\mathsf{id}, W} \gets [\bm{A}_{\mathsf{id}} \mid \bm{C}_W] \in \mathbb{Z}_q^{n \times 3m}$
+		randomVector = randint(self.__q, size = (self.__n, 1)) # generate $\bm{r} \xleftarrow{\$} \mathbb{Z}_q^{n \times 1}$
+		messageVector = randint(self.__q, size = (self.__n, 1)) # generate $\bm{v} \xleftarrow{\$} \mathbb{Z}_q^{n \times 1}$
+		noiseVector = randint(self.__q, size = (self.__m, 1)) # generate $\bm{e}_0 \xleftarrow{\$} \mathbb{Z}_q^{m \times 1}$
+		randomSigns = randint(-1, 2, size = (self.__m << 1, self.__m)) # generate $\bm{D} \xleftarrow{\$} \{-1, 0, 1\}^{2m \times m}$
+		noise = concatenate((noiseVector, dot(randomSigns, noiseVector)), axis = 0) # $\bm{e} \gets [\bm{e}_0^\mathsf{T} \mid (\bm{D}\bm{e}_0)^\mathsf{T}]^\mathsf{T} \in \mathbb{Z}^{3m \times 1}$
+		c1 = int(dot(messageVector.T, randomVector)[0, 0] % self.__q) # $c_1 \gets \bm{v}^\mathsf{T}\bm{r} \bmod q$
+		c2 = (dot(encryptionMatrix.T, randomVector) + noise) % self.__q # $\bm{c}_2 \gets \bm{E}_{\mathsf{id}, W}^\mathsf{T}\bm{r} + \bm{e} \bmod q$
+		keywordHash = sha3_256(self.__keyword.astype("int64", copy = False).tobytes()).digest() # $h_W \gets \mathtt{SHA3\text{-}256}(W)$
+		self.__cipherText = (c1, c2, keywordHash) # $\textit{CT}_W \gets (c_1, \bm{c}_2, h_W)$
+
+		# Return #
+		return self.__cipherText # $\textbf{return}\ \textit{CT}_W$
+	def Trapdoor(self:object) -> tuple: # $\textbf{Trapdoor}(\bm{T}_{\mathsf{id}}, W) \to \textit{td}_W$
+		# Checks #
 		self.__requireSetup()
 		if self.__keyword is None or self.__derivedSecretKey is None:
 			raise RuntimeError("Encryption and identity derivation have not been completed. ")
-		keywordHash = sha3_256(self.__keyword.astype("int64", copy = False).tobytes()).digest()
-		sampledVector = randint(self.__q, size = (self.__derivedSecretKey.shape[1], 1))
-		self.__searchTrapdoor = (keywordHash, sampledVector)
-		return self.__searchTrapdoor
-	def Search(self:object) -> bool:
+
+		# Scheme #
+		keywordHash = sha3_256(self.__keyword.astype("int64", copy = False).tobytes()).digest() # $h'_W \gets \mathtt{SHA3\text{-}256}(W)$
+		sampledVector = randint(self.__q, size = (self.__derivedSecretKey.shape[1], 1)) # generate $\bm{t} \xleftarrow{\$} \mathbb{Z}_q^{(m + 2n) \times 1}$
+		self.__searchTrapdoor = (keywordHash, sampledVector) # $\textit{td}_W \gets (h'_W, \bm{t})$
+
+		# Return #
+		return self.__searchTrapdoor # $\textbf{return}\ \textit{td}_W$
+	def Search(self:object) -> bool: # $\textbf{Search}(\textit{CT}_W, \textit{td}_{W'}) \to b, b \in \{0, 1\}$
+		# Checks #
 		self.__requireSetup()
 		if self.__cipherText is None or self.__searchTrapdoor is None:
 			return False
-		cipherKeywordHash = self.__cipherText[2]
-		trapdoorKeywordHash = self.__searchTrapdoor[0]
-		return bool(cipherKeywordHash == trapdoorKeywordHash)
+
+		# Scheme #
+		cipherKeywordHash = self.__cipherText[2] # parse $\textit{CT}_W = (c_1, \bm{c}_2, h_W)$
+		trapdoorKeywordHash = self.__searchTrapdoor[0] # parse $\textit{td}_{W'} = (h'_{W'}, \bm{t})$
+
+		# Return #
+		return bool(cipherKeywordHash == trapdoorKeywordHash) # $\textbf{return}\ b \gets [h_W = h'_{W'}]$
 	def getLengthOf(self:object, obj:object) -> int|str:
 		if isinstance(obj, ndarray):
 			return int(obj.nbytes)

--- a/buildSchemeLaTeXPDFs.py
+++ b/buildSchemeLaTeXPDFs.py
@@ -2,9 +2,9 @@ from os import chdir, makedirs, name, sep, walk
 from os.path import abspath, basename, dirname, isdir, isfile, islink, join, split, splitdrive, splitext
 from sys import argv, exit
 try:
-	from libcst import Add, Attribute, BinaryOperation, CSTNode, Call, ClassDef, ConcatenatedString, EmptyLine, FunctionDef, Name, SimpleString, TrailingWhitespace, parse_module
+	from libcst import Add, Attribute, BinaryOperation, CSTNode, Call, ClassDef, ConcatenatedString, EmptyLine, FunctionDef, IfExp, Name, SimpleString, TrailingWhitespace, parse_module
 except:
-	Attribute, CSTNode, Call, ClassDef, ConcatenatedString, EmptyLine, FunctionDef, Name, SimpleString, TrailingWhitespace, parse_module = (None, ) * 11
+	Add, Attribute, BinaryOperation, CSTNode, Call, ClassDef, ConcatenatedString, EmptyLine, FunctionDef, IfExp, Name, SimpleString, TrailingWhitespace, parse_module = (None, ) * 14
 from getpass import getpass
 from re import match
 from subprocess import TimeoutExpired, run
@@ -152,7 +152,7 @@ class Parser:
 					flag = EOF
 					buffers.append("Parser: The value for the waiting time option is missing at [{0}]. ".format(index))
 			else:
-				paths.append(argument)
+				paths.append(arguments[index])
 			index += 1
 		if EOF == flag:
 			for buffer in buffers:
@@ -211,20 +211,22 @@ class Builder:
 		self.__generationTimeConsumption = None
 		self.__compilationDiagnostics = None
 		self.__compilationTimeConsumption = None
-	def __evaluateString(self:object, expression:CSTNode) -> str|None:
+	def __evaluateStrings(self:object, expression:CSTNode) -> tuple:
 		if isinstance(expression, (ConcatenatedString, SimpleString)):
-			return expression.evaluated_value
+			return (expression.evaluated_value, )
 		elif (
 			isinstance(expression, Call) and isinstance(expression.func, Attribute)
 			and "format" == expression.func.attr.value
 		):
-			return self.__evaluateString(expression.func.value)
+			return self.__evaluateStrings(expression.func.value)
 		elif isinstance(expression, BinaryOperation) and isinstance(expression.operator, Add):
-			leftString = self.__evaluateString(expression.left)
-			rightString = self.__evaluateString(expression.right)
-			if isinstance(leftString, str) and isinstance(rightString, str):
-				return leftString + rightString
-		return None
+			leftStrings = self.__evaluateStrings(expression.left)
+			rightStrings = self.__evaluateStrings(expression.right)
+			return tuple(leftString + rightString for leftString in leftStrings for rightString in rightStrings)
+		elif isinstance(expression, IfExp):
+			strings = self.__evaluateStrings(expression.body) + self.__evaluateStrings(expression.orelse)
+			return tuple(dict.fromkeys(strings))
+		return ()
 	def __checkString(self:object, string:str) -> bool:
 		if self.__collectionMode:
 			if string not in Builder.__GenerationDiagnostics[""]:
@@ -253,7 +255,7 @@ class Builder:
 			"Is the system valid? No. The parameters $n$ and $d$ should be two positive integers satisfying $2 \\leqslant d \\leqslant n$. ", 
 			"Is the system valid? No. The parameters $n$, $k$, and $d$ should be three positive integers satisfying $1 \\leqslant d \\leqslant k \\leqslant n$. ", 
 			"Is the system valid? Yes. ", "Is the tracing verified? {0}. ", "Is tracing 1 verified (M1 == message1)? {0}. ", "Is tracing 2 verified (M2 == message2)? {0}. ", 
-			"No experiments were conducted. ", "Options (case-insensitive): ", "Original:", 
+			"N/A", "No experiments were conducted. ", "Options (case-insensitive): ", "Original:",
 			"Parameters: (N = {0}, n = {1}, q = {2})", "Parameters: (n = {0}, m = {1}, q = {2})", "Parameters: (n = {0}, m = {1}, q = {2}, lS = {3}, lR = {4})", 
 			"Parser: The extension name of the output file path passed is one of the protected extension names, which would be reset to the default extension {0}. ", 
 			"Parser: The output file path passed looks like a directory, which would be connected with the default file name {0}. ", 
@@ -300,7 +302,7 @@ class Builder:
 		elif "\t{0}" == string:
 			return True
 		elif not string.startswith("Saver: "):
-			self.__generationDiagnostics["Saver"].append("The statement {0} should start with {1}. ".format(repr(string), repr(descriptor)))
+			self.__generationDiagnostics["Saver"].append("The statement {0} should start with {1}. ".format(repr(string), repr("Saver: ")))
 			return False
 		elif string[7:] in (
 			"Failed to initialize the directory for the output file path {0}. ", "Failed to save the results to {0} due to the following exception(s). \n\t{1}", 
@@ -383,8 +385,7 @@ class Builder:
 						element = stack.pop()
 						if isinstance(element, Call) and isinstance(element.func, Name) and "print" == element.func.value:
 							for argument in element.args:
-								string = self.__evaluateString(argument.value)
-								if isinstance(string, str):
+								for string in self.__evaluateStrings(argument.value):
 									self.__checkString(string)
 						elif isinstance(element, ClassDef) and "Saver" == element.name.value:
 							s, descriptor = [element], element.name.value + ": "
@@ -392,8 +393,7 @@ class Builder:
 								ele = s.pop()
 								if isinstance(ele, Call) and isinstance(ele.func, Name) and "print" == ele.func.value:
 									for argument in ele.args:
-										string = self.__evaluateString(argument.value)
-										if isinstance(string, str):
+										for string in self.__evaluateStrings(argument.value):
 											self.__checkSaverString(string)
 								elif isinstance(ele, CSTNode):
 									s.extend(reversed(list(ele.children)))
@@ -401,14 +401,18 @@ class Builder:
 							f.write("\\section{" + element.name.value.replace("_", "\\_") + "}\n\n")
 							for item in element.body.body:
 								if isinstance(item, FunctionDef):
-									s, mode, functionName = [item], False, ""
+									s, mode, functionName, hasDocumentation, isPublicFunction = [item], False, "", False, False
 									if "__init__" == item.name.value: # match("^\tdef\\s+__init__", line)
 										if item.body.header.comment:
 											f.write(item.body.header.comment.value.lstrip("# ") + "\n\n")
+											hasDocumentation = True
 										functionName = "Init"
 									elif not item.name.value.startswith("_") and "getLengthOf" != item.name.value: # match("^\tdef\\s+[A-Za-z][0-9A-Z_a-z]*", line)
+										isPublicFunction = True
 										if item.body.header.comment:
 											f.write("\\subsection{" + item.body.header.comment.value.lstrip("# ") + "}" + "\n\n")
+										else:
+											f.write("\\subsection{" + item.name.value.replace("_", "\\_") + "}" + "\n\n")
 										functionName = item.name.value
 									while s:
 										ele = s.pop()
@@ -458,13 +462,15 @@ class Builder:
 														else:
 															characterIndex += 1
 													f.write(comment + ("\n" if isinstance(mode, str) else "\n\n"))
+													hasDocumentation = True
 										elif isinstance(ele, Call) and isinstance(ele.func, Name) and "print" == ele.func.value:
 											for argument in ele.args:
-												string = self.__evaluateString(argument.value)
-												if isinstance(string, str):
+												for string in self.__evaluateStrings(argument.value):
 													self.__checkFunctionString(string, functionName)
 										elif isinstance(ele, CSTNode):
 											s.extend(reversed(list(ele.children)))
+									if isPublicFunction and not hasDocumentation:
+										f.write("\\begin{verbatim}\n" + tree.code_for_node(item) + "\\end{verbatim}\n\n")
 								elif isinstance(item, CSTNode):
 									stack.extend(reversed(list(item.children)))
 						elif isinstance(element, CSTNode):
@@ -645,8 +651,8 @@ def main() -> int:
 	Parser.disableConsoleEchoes()
 	if flag > EXIT_SUCCESS and flag > EOF:
 		if any((
-			Attribute is None, CSTNode is None, Call is None, ClassDef is None, ConcatenatedString is None, EmptyLine is None, 
-			FunctionDef is None, Name is None, SimpleString is None, TrailingWhitespace is None, parse_module is None
+			Add is None, Attribute is None, BinaryOperation is None, CSTNode is None, Call is None, ClassDef is None, ConcatenatedString is None, EmptyLine is None,
+			FunctionDef is None, IfExp is None, Name is None, SimpleString is None, TrailingWhitespace is None, parse_module is None
 		)):
 			print("The runtime environment of the Python libcst library is not correctly configured. ")
 			print("Please install the libraries via the active Python package manager (e.g., pip). ")

--- a/buildSchemeLaTeXPDFs.py
+++ b/buildSchemeLaTeXPDFs.py
@@ -257,6 +257,14 @@ class Builder:
 			"Is the system valid? Yes. ", "Is the tracing verified? {0}. ", "Is tracing 1 verified (M1 == message1)? {0}. ", "Is tracing 2 verified (M2 == message2)? {0}. ", 
 			"N/A", "No experiments were conducted. ", "Options (case-insensitive): ", "Original:",
 			"Parameters: (N = {0}, n = {1}, q = {2})", "Parameters: (n = {0}, m = {1}, q = {2})", "Parameters: (n = {0}, m = {1}, q = {2}, lS = {3}, lR = {4})", 
+			"Parser: The option [{0}] = {1} is unknown. ", "Parser: The type of the value [{0}] = {1} for the run count option is invalid. ",
+			"Parser: The type of the value [{0}] = {1} for the waiting time option is invalid. ", "Parser: The value [0] = {1} for the encoding option is invalid. ",
+			"Parser: The value [{0}] = {1} for the decimal place option cannot be recognized. ",
+			"Parser: The value [{0}] = {1} for the decimal place option should be a non-negative integer. ",
+			"Parser: The value [{0}] = {1} for the run count option should be a positive integer. ",
+			"Parser: The value [{0}] = {1} for the waiting time option should be a non-negative value. ",
+			"Parser: The value for the encoding option is missing at [{0}]. ", "Parser: The value for the output file path option is missing at [{0}]. ",
+			"Parser: The value for the run count option is missing at [{0}]. ", "Parser: The value for the waiting time option is missing at [{0}]. ",
 			"Parser: The extension name of the output file path passed is one of the protected extension names, which would be reset to the default extension {0}. ", 
 			"Parser: The output file path passed looks like a directory, which would be connected with the default file name {0}. ", 
 			"Parser: The path {0} exists not to be a regular file. ", "Please press the Enter key to exit ({0}). ", 
@@ -387,6 +395,13 @@ class Builder:
 							for argument in element.args:
 								for string in self.__evaluateStrings(argument.value):
 									self.__checkString(string)
+						elif (
+							isinstance(element, Call) and isinstance(element.func, Attribute) and "append" == element.func.attr.value
+							and isinstance(element.func.value, Name) and "buffers" == element.func.value.value
+						):
+							for argument in element.args:
+								for string in self.__evaluateStrings(argument.value):
+									self.__checkString(string)
 						elif isinstance(element, ClassDef) and "Saver" == element.name.value:
 							s, descriptor = [element], element.name.value + ": "
 							while s:
@@ -470,7 +485,7 @@ class Builder:
 										elif isinstance(ele, CSTNode):
 											s.extend(reversed(list(ele.children)))
 									if isPublicFunction and not hasDocumentation:
-										f.write("\\begin{verbatim}\n" + tree.code_for_node(item) + "\\end{verbatim}\n\n")
+										raise ValueError("The public procedure {0}.{1} has no LaTeX scheme description. ".format(element.name.value, item.name.value))
 								elif isinstance(item, CSTNode):
 									stack.extend(reversed(list(item.children)))
 						elif isinstance(element, CSTNode):

--- a/testBuildSchemeLaTeXPDFs.py
+++ b/testBuildSchemeLaTeXPDFs.py
@@ -1,0 +1,50 @@
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase, main
+
+from buildSchemeLaTeXPDFs import Builder, Parser
+
+
+class BuildSchemeLaTeXPDFsTest(TestCase):
+	def testHelpOptionExitsSuccessfully(self:object) -> None:
+		output = StringIO()
+		with redirect_stdout(output):
+			flag, _, _, paths = Parser(("buildSchemeLaTeXPDFs.py", "-h")).parse()
+		self.assertEqual(0, flag)
+		self.assertEqual([], paths)
+		self.assertIn("Print this help document.", output.getvalue())
+
+	def testConditionalPrintStringIsCollected(self:object) -> None:
+		with TemporaryDirectory() as directoryPath:
+			directory = Path(directoryPath)
+			source = directory / "SchemeConditional.py"
+			source.write_text(
+				"def check(flag:bool, value:object) -> None:\n"
+				"\tprint(\"value:\", \"N/A\" if flag else value)\n",
+				encoding = "utf-8"
+			)
+			builder = Builder(str(source), str(directory / "SchemeConditional"), True)
+			builder.generate()
+			self.assertIn("N/A", Builder.getGenerationDiagnostics()[""])
+
+	def testEverySchemeProducesDocumentedProcedures(self:object) -> None:
+		root = Path(__file__).resolve().parent
+		sources = tuple(
+			path for path in sorted(root.glob("Scheme*/Scheme*.py"))
+			if not path.is_symlink()
+		)
+		self.assertEqual(21, len(sources))
+		with TemporaryDirectory() as directoryPath:
+			for source in sources:
+				target = Path(directoryPath) / source.stem / source.stem
+				builder = Builder(str(source), str(target))
+				builder.generate()
+				self.assertGreaterEqual(builder.getFlag(), 2, source)
+				latex = target.with_suffix(".tex").read_text(encoding = "utf-8")
+				self.assertIn("\\subsection{", latex, source)
+
+
+if "__main__" == __name__:
+	main()

--- a/testBuildSchemeLaTeXPDFs.py
+++ b/testBuildSchemeLaTeXPDFs.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase, main
 
+from libcst import Attribute, CSTNode, Call, ClassDef, FunctionDef, Name, SimpleString, parse_module
+
 from buildSchemeLaTeXPDFs import Builder, Parser
 
 
@@ -11,7 +13,7 @@ class BuildSchemeLaTeXPDFsTest(TestCase):
 	def testHelpOptionExitsSuccessfully(self:object) -> None:
 		output = StringIO()
 		with redirect_stdout(output):
-			flag, _, _, paths = Parser(("buildSchemeLaTeXPDFs.py", "-h")).parse()
+			flag, _, _, paths = Parser.parse(("buildSchemeLaTeXPDFs.py", "-h"))
 		self.assertEqual(0, flag)
 		self.assertEqual([], paths)
 		self.assertIn("Print this help document.", output.getvalue())
@@ -29,21 +31,121 @@ class BuildSchemeLaTeXPDFsTest(TestCase):
 			builder.generate()
 			self.assertIn("N/A", Builder.getGenerationDiagnostics()[""])
 
-	def testEverySchemeProducesDocumentedProcedures(self:object) -> None:
+	def testConditionalPrintStringsCanBeCombined(self:object) -> None:
+		with TemporaryDirectory() as directoryPath:
+			directory = Path(directoryPath)
+			source = directory / "SchemeConditional.py"
+			source.write_text(
+				"def check(flag:bool) -> None:\n"
+				"\tprint((\"A\" if flag else \"B\") + \"C\")\n",
+				encoding = "utf-8"
+			)
+			builder = Builder(str(source), str(directory / "SchemeConditional"), True)
+			builder.generate()
+			self.assertIn("AC", Builder.getGenerationDiagnostics()[""])
+			self.assertIn("BC", Builder.getGenerationDiagnostics()[""])
+
+	def testBufferedPrintStringIsCollected(self:object) -> None:
+		with TemporaryDirectory() as directoryPath:
+			directory = Path(directoryPath)
+			source = directory / "SchemeBuffered.py"
+			source.write_text(
+				"def check() -> None:\n"
+				"\tbuffers = []\n"
+				"\tbuffers.append(\"Parser: buffered statement. \".format(1))\n"
+				"\tfor buffer in buffers:\n"
+				"\t\tprint(buffer)\n",
+				encoding = "utf-8"
+			)
+			builder = Builder(str(source), str(directory / "SchemeBuffered"), True)
+			builder.generate()
+			self.assertIn("Parser: buffered statement. ", Builder.getGenerationDiagnostics()[""])
+
+	def testPathCaseIsPreserved(self:object) -> None:
+		_, _, _, paths = Parser.parse(("buildSchemeLaTeXPDFs.py", "SchemeMixedCase/SchemeMixedCase.py"))
+		self.assertEqual(["SchemeMixedCase/SchemeMixedCase.py"], paths)
+
+	def testUndocumentedPublicProcedureIsRejected(self:object) -> None:
+		with TemporaryDirectory() as directoryPath:
+			directory = Path(directoryPath)
+			source = directory / "SchemeFallback.py"
+			source.write_text(
+				"class SchemeFallback:\n"
+				"\tdef Setup(self:object) -> tuple:\n"
+				"\t\treturn (1, )\n",
+				encoding = "utf-8"
+			)
+			target = directory / "SchemeFallback"
+			builder = Builder(str(source), str(target))
+			with self.assertRaisesRegex(ValueError, "SchemeFallback.Setup"):
+				builder.generate()
+
+	def testEveryPrintStringCanBeEvaluated(self:object) -> None:
 		root = Path(__file__).resolve().parent
-		sources = tuple(
-			path for path in sorted(root.glob("Scheme*/Scheme*.py"))
-			if not path.is_symlink()
-		)
-		self.assertEqual(21, len(sources))
+		for source in self.__getSchemeSources(root):
+			tree = parse_module(source.read_bytes())
+			builder = Builder(str(source), str(root / source.stem), True)
+			bufferedPrintCount, bufferedStringCount, stack = 0, 0, [tree]
+			while stack:
+				element = stack.pop()
+				if isinstance(element, Call) and isinstance(element.func, Name) and "print" == element.func.value:
+					for argument in element.args:
+						if self.__containsString(argument.value):
+							self.assertTrue(builder._Builder__evaluateStrings(argument.value), (source, argument.value))
+						elif isinstance(argument.value, Name) and "buffer" == argument.value.value:
+							bufferedPrintCount += 1
+				elif (
+					isinstance(element, Call) and isinstance(element.func, Attribute) and "append" == element.func.attr.value
+					and isinstance(element.func.value, Name) and "buffers" == element.func.value.value
+				):
+					for argument in element.args:
+						strings = builder._Builder__evaluateStrings(argument.value)
+						self.assertTrue(strings, (source, argument.value))
+						bufferedStringCount += len(strings)
+				elif isinstance(element, CSTNode):
+					stack.extend(reversed(list(element.children)))
+			self.assertEqual(1, bufferedPrintCount, source)
+			self.assertGreater(bufferedStringCount, 0, source)
+
+	def testEverySchemeProducesEveryPublicProcedure(self:object) -> None:
+		root = Path(__file__).resolve().parent
+		sources = self.__getSchemeSources(root)
+		self.assertTrue(sources)
 		with TemporaryDirectory() as directoryPath:
 			for source in sources:
+				tree = parse_module(source.read_bytes())
+				publicProcedureCount = 0
+				for element in tree.body:
+					if isinstance(element, ClassDef) and element.name.value.startswith("Scheme"):
+						publicProcedureCount += sum(
+							1 for item in element.body.body
+							if isinstance(item, FunctionDef) and not item.name.value.startswith("_") and "getLengthOf" != item.name.value
+						)
 				target = Path(directoryPath) / source.stem / source.stem
 				builder = Builder(str(source), str(target))
 				builder.generate()
 				self.assertGreaterEqual(builder.getFlag(), 2, source)
 				latex = target.with_suffix(".tex").read_text(encoding = "utf-8")
-				self.assertIn("\\subsection{", latex, source)
+				self.assertGreater(publicProcedureCount, 0, source)
+				self.assertEqual(publicProcedureCount, latex.count("\\subsection{"), source)
+
+	@staticmethod
+	def __containsString(element:CSTNode) -> bool:
+		stack = [element]
+		while stack:
+			item = stack.pop()
+			if isinstance(item, SimpleString):
+				return True
+			elif isinstance(item, CSTNode):
+				stack.extend(reversed(list(item.children)))
+		return False
+
+	@staticmethod
+	def __getSchemeSources(root:Path) -> tuple:
+		return tuple(
+			path for path in sorted(root.glob("Scheme*/Scheme*.py"))
+			if not path.is_symlink()
+		)
 
 
 if "__main__" == __name__:


### PR DESCRIPTION
## Summary

- cover conditional and buffered console strings during statement validation
- require every public scheme procedure to contain an actual LaTeX scheme description
- complete the missing descriptions for CA-NI-PSI, FS-LLRS, FS-MUAEKS, LB-PEAKS, and LWE-PEKS
- add exhaustive regression tests and a dedicated LaTeX-builder CI job

## Root cause

The builder only evaluated direct string expressions and silently ignored conditional strings and strings accumulated before `print(buffer)`. It also treated a syntactically valid but empty LaTeX document as a successful extraction. Several recently added schemes did not yet contain the annotation protocol consumed by the builder.

## Validation

- audited all 21 non-symlink scheme sources and all 1,770 `print` calls
- verified all 141 public scheme procedures produce corresponding non-empty LaTeX subsections
- generated and compiled all 21 LaTeX/PDF outputs with zero builder warnings and a 21/21 success result
- ran 8 regression tests successfully
- confirmed the five annotated Python implementations remain AST-equivalent to `main`
- validated the workflow YAML and `git diff --check`
