### PR TITLE
Improve coefficient computation runtime output

### DIFF
--- a/SchemeCoefficientComputation/SchemeCoefficientComputation.py
+++ b/SchemeCoefficientComputation/SchemeCoefficientComputation.py
@@ -855,10 +855,22 @@ class SchemeCoefficientComputation:
 		validators = tuple(value for value in result if type(value) is bool) if isinstance(result, (tuple, list)) else tuple()
 		return bool(validators) and all(validators)
 	@staticmethod
-	def __printResults(results:tuple|list) -> None:
-		print("\t".join(TABLE_HEADER))
-		for result in results:
-			print("\t".join(str(value) for value in result))
+	def __printResult(result:tuple|list) -> None:
+		if isinstance(result, (tuple, list)) and len(result) == len(TABLE_HEADER):
+			one = result[2] is True or result[2] == "Reliable"
+			print("Target: {0}".format(result[0]))
+			print("Curve: {0}".format(result[1]))
+			print("Is ``group.init(type, 1)`` reliable? {0}.".format("Yes" if one else "No"))
+			print("Scheme: {0}".format(result[3]))
+			print("run: {0}".format(result[4]))
+			print("Correctness: {0} / {1}".format(result[5], result[4]))
+			print("Time: {0}".format(result[6]))
+			print(flush = True)
+	@staticmethod
+	def __recordResult(results:list, result:list, isVerbose:bool) -> None:
+		results.append(result)
+		if isVerbose is not False:
+			SchemeCoefficientComputation.__printResult(result)
 	def updateFilePaths(self:object, *paths:tuple) -> int:
 		originalLength, stack = len(self.__filePaths), list(reversed(paths))
 		while stack:
@@ -917,7 +929,9 @@ class SchemeCoefficientComputation:
 						print("Basic: {0} failed on {1} due to {2}. ".format(self.__solutionName(constant2HighestSolution), curveType, repr(e)))
 					raise e########
 				endTime = perf_counter()
-				results.append(["Dry run", curveType, "Reliable", self.__solutionName(constant2HighestSolution), runCount, correctness, (endTime - startTime) / runCount])
+				self.__recordResult(
+					results, ["Dry run", curveType, "Reliable", self.__solutionName(constant2HighestSolution), runCount, correctness, (endTime - startTime) / runCount], isVerbose
+				)
 			for highest2ConstantSolution in Solutions.Highest2Constant.getAllSolutions():
 				startTime = perf_counter()
 				try:
@@ -928,7 +942,9 @@ class SchemeCoefficientComputation:
 					if isVerbose is not False:
 						print("Basic: {0} failed on {1} due to {2}. ".format(self.__solutionName(highest2ConstantSolution), curveType, repr(e)))
 				endTime = perf_counter()
-				results.append(["Dry run", curveType, "Reliable", self.__solutionName(highest2ConstantSolution), runCount, correctness, (endTime - startTime) / runCount])
+				self.__recordResult(
+					results, ["Dry run", curveType, "Reliable", self.__solutionName(highest2ConstantSolution), runCount, correctness, (endTime - startTime) / runCount], isVerbose
+				)
 			
 			# Flawed #
 			group.init = lambda a, b:group.random(a) # Patch the ``group.init`` to simulate the issue
@@ -943,7 +959,9 @@ class SchemeCoefficientComputation:
 					if isVerbose is not False:
 						print("Basic: {0} failed on {1} due to {2}. ".format(self.__solutionName(constant2HighestSolution), curveType, repr(e)))
 				endTime = perf_counter()
-				results.append(["Dry run", curveType, "Unreliable", self.__solutionName(constant2HighestSolution), runCount, correctness, (endTime - startTime) / runCount])
+				self.__recordResult(
+					results, ["Dry run", curveType, "Unreliable", self.__solutionName(constant2HighestSolution), runCount, correctness, (endTime - startTime) / runCount], isVerbose
+				)
 			for highest2ConstantSolution in Solutions.Highest2Constant.getAllSolutions():
 				startTime = perf_counter()
 				try:
@@ -954,7 +972,9 @@ class SchemeCoefficientComputation:
 					if isVerbose is not False:
 						print("Basic: {0} failed on {1} due to {2}. ".format(self.__solutionName(highest2ConstantSolution), curveType, repr(e)))
 				endTime = perf_counter()
-				results.append(["Dry run", curveType, "Unreliable", self.__solutionName(highest2ConstantSolution), runCount, correctness, (endTime - startTime) / runCount])
+				self.__recordResult(
+					results, ["Dry run", curveType, "Unreliable", self.__solutionName(highest2ConstantSolution), runCount, correctness, (endTime - startTime) / runCount], isVerbose
+				)
 		return results
 	@staticmethod
 	def __buildPatchedNamespace(filePath:str, sourceTree:ast.Module, solution:object, one:bool) -> tuple:
@@ -1007,14 +1027,14 @@ class SchemeCoefficientComputation:
 								if isVerbose is not False:
 									print("Device: {0} failed on {1} due to {2}. ".format(target, curveType, repr(e)))
 						endTime = perf_counter()
-						results.append([target, curveType, one, self.__solutionName(solution), runCount, correctness, (endTime - startTime) / runCount])
+						self.__recordResult(
+							results, [target, curveType, one, self.__solutionName(solution), runCount, correctness, (endTime - startTime) / runCount], isVerbose
+						)
 		return results
 	def conductScheme(self:object, r:int = __DefaultRunCount, isVerbose:bool = True) -> list:
 		runCount, results = r if isinstance(r, int) and r >= 1 else SchemeCoefficientComputation.__DefaultRunCount, []
 		results.extend(self.__conductBasicScheme(r = runCount, isVerbose = isVerbose))
 		results.extend(self.__conductDeviceScheme(r = runCount, isVerbose = isVerbose))
-		if isVerbose is not False:
-			self.__printResults(results)
 		return results
 
 

--- a/docs/superpowers/plans/2026-08-16-coefficient-runtime-output.md
+++ b/docs/superpowers/plans/2026-08-16-coefficient-runtime-output.md
@@ -1,0 +1,42 @@
+# Coefficient Computation Runtime Output Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Print each completed coefficient-comparison result immediately in non-quiet mode while preserving quiet mode and all computation results.
+
+**Architecture:** Add one private formatter for a result row and one private recorder that appends the unchanged row before conditionally printing it. Route all basic and device result creation through the recorder and remove the final bulk table print.
+
+**Tech Stack:** Python 3 standard library, `unittest`, fake Charm-Crypto modules for deterministic tests.
+
+---
+
+### Task 1: Runtime output regression tests
+
+**Files:**
+- Create: `testSchemeCoefficientComputation.py`
+
+- [x] Write a test that interrupts the device phase and asserts that completed basic results were already printed as labeled blocks.
+- [x] Write a quiet-mode test that asserts no per-result output is produced.
+- [x] Run `python3 -m unittest -v testSchemeCoefficientComputation.py` and verify the verbose test fails because output is currently delayed until the end.
+
+### Task 2: Incremental result reporting
+
+**Files:**
+- Modify: `SchemeCoefficientComputation/SchemeCoefficientComputation.py`
+
+- [x] Replace the bulk table printer with a single-result block formatter.
+- [x] Add a recorder that appends each unchanged result and prints it only when `isVerbose is not False`.
+- [x] Route all five basic/device append sites through the recorder.
+- [x] Remove the final bulk print from `conductScheme`.
+- [x] Re-run the focused tests and verify both pass.
+
+### Task 3: Complete verification
+
+**Files:**
+- Verify: `SchemeCoefficientComputation/SchemeCoefficientComputation.py`
+- Verify: `testSchemeCoefficientComputation.py`
+
+- [x] Run static compilation.
+- [x] Run the focused unit tests.
+- [x] Run verbose and quiet command-line smoke tests with fake Charm-Crypto and confirm the output contract.
+- [x] Inspect the diff to confirm calculation and saved-result rows are unchanged.

--- a/docs/superpowers/specs/2026-08-16-coefficient-runtime-output-design.md
+++ b/docs/superpowers/specs/2026-08-16-coefficient-runtime-output-design.md
@@ -1,0 +1,15 @@
+# Coefficient Computation Runtime Output Design
+
+## Goal
+
+Make `SchemeCoefficientComputation.py` report completed comparison results while a non-quiet execution is still running, using the block-oriented console style of the other scheme programs.
+
+## Behavior
+
+Each completed seven-field result is printed immediately with the target, curve, multiplicative-identity reliability, solution, run count, correctness count, and average time on separate lines, followed by a blank line. The existing result row, timing, correctness, saving, and exit-status contracts remain unchanged.
+
+The `-q`, `/q`, and equivalent quiet options continue to suppress all per-result output. Diagnostics for actual failures retain their existing behavior. The final tab-separated table is removed to avoid duplicate output after incremental reporting.
+
+## Verification
+
+A focused unit test uses a fake Charm-Crypto environment. It proves that output is already present if device comparison is interrupted after the basic phase, verifies the block labels, and verifies that quiet mode produces no output. Static compilation and a command-line smoke test cover the complete file.

--- a/testSchemeCoefficientComputation.py
+++ b/testSchemeCoefficientComputation.py
@@ -1,0 +1,118 @@
+import importlib.util
+import io
+import os
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+
+
+SOURCE_PATH = os.path.join(
+	os.path.dirname(__file__), "SchemeCoefficientComputation", "SchemeCoefficientComputation.py"
+)
+
+
+class FakeElement:
+	def __init__(self:object, elementType:object, value:int) -> object:
+		self.type = elementType
+		self.value = value
+	def __add__(self:object, other:object) -> object:
+		return FakeElement(self.type, self.value + self.__value(other))
+	def __eq__(self:object, other:object) -> bool:
+		return isinstance(other, FakeElement) and self.type == other.type and self.value == other.value
+	def __mul__(self:object, other:object) -> object:
+		return FakeElement(self.type, self.value * self.__value(other))
+	def __neg__(self:object) -> object:
+		return FakeElement(self.type, -self.value)
+	def __repr__(self:object) -> str:
+		return "FakeElement({0}, {1})".format(repr(self.type), self.value)
+	def __radd__(self:object, other:object) -> object:
+		return self + other
+	def __rmul__(self:object, other:object) -> object:
+		return self * other
+	@staticmethod
+	def __value(value:object) -> int:
+		return value.value if isinstance(value, FakeElement) else value
+
+
+class FakePairingGroup:
+	def __init__(self:object, curveType:str) -> object:
+		self.curveType = curveType
+		self.__randomValue = 100
+	def init(self:object, elementType:object, value:int) -> FakeElement:
+		return FakeElement(elementType, value)
+	def random(self:object, elementType:object) -> FakeElement:
+		self.__randomValue += 1
+		return FakeElement(elementType, self.__randomValue)
+
+
+def loadModule() -> object:
+	charm = types.ModuleType("charm")
+	toolbox = types.ModuleType("charm.toolbox")
+	pairingGroup = types.ModuleType("charm.toolbox.pairinggroup")
+	pairingGroup.PairingGroup = FakePairingGroup
+	pairingGroup.ZR = "ZR"
+	pairingGroup.pc_element = FakeElement
+	modules = {
+		"charm":charm,
+		"charm.toolbox":toolbox,
+		"charm.toolbox.pairinggroup":pairingGroup
+	}
+	originalModules = {name:sys.modules.get(name) for name in modules}
+	originalDirectory = os.getcwd()
+	try:
+		sys.modules.update(modules)
+		specification = importlib.util.spec_from_file_location("scheme_coefficient_computation_test", SOURCE_PATH)
+		module = importlib.util.module_from_spec(specification)
+		specification.loader.exec_module(module)
+		return module
+	finally:
+		os.chdir(originalDirectory)
+		for name, originalModule in originalModules.items():
+			if originalModule is None:
+				sys.modules.pop(name, None)
+			else:
+				sys.modules[name] = originalModule
+
+
+class RuntimeOutputTests(unittest.TestCase):
+	def testVerboseResultsArePrintedBeforeDevicePhaseFinishes(self:object) -> None:
+		module = loadModule()
+		comparator = module.SchemeCoefficientComputation()
+		def interruptDevicePhase(**kwargs:dict) -> list:
+			raise RuntimeError("stop after the basic phase")
+		setattr(comparator, "_SchemeCoefficientComputation__conductDeviceScheme", interruptDevicePhase)
+		output = io.StringIO()
+		with self.assertRaisesRegex(RuntimeError, "stop after the basic phase"), redirect_stdout(output):
+			comparator.conductScheme(r = 1, isVerbose = True)
+		text = output.getvalue()
+		self.assertIn("Target: Dry run\n", text)
+		self.assertIn("Curve: MNT201\n", text)
+		self.assertIn("Is ``group.init(type, 1)`` reliable? Yes.\n", text)
+		self.assertIn("Is ``group.init(type, 1)`` reliable? No.\n", text)
+		self.assertIn("Scheme: Constant2Highest.", text)
+		self.assertIn("run: 1\n", text)
+		self.assertIn("Correctness: 1 / 1\n", text)
+		self.assertIn("Time: ", text)
+		expectedResultCount = (
+			len(module.Solutions.Constant2Highest.getAllSolutions()) + len(module.Solutions.Highest2Constant.getAllSolutions())
+		) * 2 * 3
+		self.assertEqual(expectedResultCount, text.count("Target: "))
+		self.assertNotIn("\t".join(module.TABLE_HEADER), text)
+	def testQuietModeSuppressesResultOutput(self:object) -> None:
+		module = loadModule()
+		comparator = module.SchemeCoefficientComputation()
+		output = io.StringIO()
+		with redirect_stdout(output):
+			results = comparator._SchemeCoefficientComputation__conductBasicScheme(r = 1, isVerbose = False)
+		expectedResultCount = (
+			len(module.Solutions.Constant2Highest.getAllSolutions()) + len(module.Solutions.Highest2Constant.getAllSolutions())
+		) * 2 * 3
+		self.assertEqual(expectedResultCount, len(results))
+		self.assertTrue(all(len(result) == len(module.TABLE_HEADER) for result in results))
+		self.assertEqual("", output.getvalue())
+		self.assertFalse(module.Parser.parse(("SchemeCoefficientComputation.py", "/q"))[4])
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary

- print each completed coefficient-comparison result immediately in non-quiet mode
- format runtime results as readable labeled blocks and flush each block to the console
- preserve `/q` behavior, calculation logic, correctness statistics, and saved result rows
- add focused regression tests for incremental output and quiet mode

## Root cause

`SchemeCoefficientComputation.conductScheme` collected all basic and device results before printing one final tab-separated table. Long-running comparisons therefore appeared to produce no progress output.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v testSchemeCoefficientComputation.py`
- static compilation of the implementation and regression test
- verbose and `/q` command-line smoke tests with a deterministic fake Charm-Crypto environment
- AST comparison confirming all five saved-result row expressions are unchanged from `origin/main`
- `git diff origin/main...HEAD --check`
