### PR TITLE
Correct Python help scheme names

### DIFF
--- a/SchemeAAIBME/SchemeFuzzyME.py
+++ b/SchemeAAIBME/SchemeFuzzyME.py
@@ -58,7 +58,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the Fuzzy-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeCANIFPPCT/SchemeCANIFPPCT.py
+++ b/SchemeCANIFPPCT/SchemeCANIFPPCT.py
@@ -57,7 +57,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the CA-NI-FPPCT cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeCANIFPPCT/SchemeCANIPSI.py
+++ b/SchemeCANIFPPCT/SchemeCANIPSI.py
@@ -57,7 +57,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the CA-NI-PSI cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeFSLLRS/SchemeFSLLRS.py
+++ b/SchemeFSLLRS/SchemeFSLLRS.py
@@ -53,7 +53,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the FS-LLRS cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeFSMUAEKS/SchemeFSMUAEKS.py
+++ b/SchemeFSMUAEKS/SchemeFSMUAEKS.py
@@ -56,7 +56,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the FS-MUAEKS cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeHIBME/SchemeAnonymousME.py
+++ b/SchemeHIBME/SchemeAnonymousME.py
@@ -56,7 +56,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the AnonymousME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeHIBME/SchemeHIBME.py
+++ b/SchemeHIBME/SchemeHIBME.py
@@ -57,7 +57,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the HIB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBMEMR/SchemeIBBME.py
+++ b/SchemeIBMEMR/SchemeIBBME.py
@@ -57,7 +57,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the IBBME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBMEMR/SchemeIBMEMR.py
+++ b/SchemeIBMEMR/SchemeIBMEMR.py
@@ -58,7 +58,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the IBMEMR cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBMETR/SchemeAIBE.py
+++ b/SchemeIBMETR/SchemeAIBE.py
@@ -56,7 +56,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the AIBE cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBMETR/SchemeARES.py
+++ b/SchemeIBMETR/SchemeARES.py
@@ -57,7 +57,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the ARES cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBMETR/SchemeIBME.py
+++ b/SchemeIBMETR/SchemeIBME.py
@@ -57,7 +57,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the IBME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBMETR/SchemeIBMECH.py
+++ b/SchemeIBMETR/SchemeIBMECH.py
@@ -57,7 +57,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the IBMECH cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBMETR/SchemeIBMETR.py
+++ b/SchemeIBMETR/SchemeIBMETR.py
@@ -57,7 +57,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the IBMETR cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBPRME/SchemeIBPME.py
+++ b/SchemeIBPRME/SchemeIBPME.py
@@ -59,7 +59,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the IBPME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBPRME/SchemeIBPRME.py
+++ b/SchemeIBPRME/SchemeIBPRME.py
@@ -58,7 +58,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the IBPRME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeIBPRME/SchemePBAC.py
+++ b/SchemeIBPRME/SchemePBAC.py
@@ -59,7 +59,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the PBAC cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeLBPEAKS/SchemeLBPEAKS.py
+++ b/SchemeLBPEAKS/SchemeLBPEAKS.py
@@ -55,7 +55,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the LB-PEAKS cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeLWEPEKS/SchemeLWEPEKS.py
+++ b/SchemeLWEPEKS/SchemeLWEPEKS.py
@@ -53,7 +53,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the LWE-PEKS cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(

--- a/SchemeVLPSICA/SchemeVLPSICA.py
+++ b/SchemeVLPSICA/SchemeVLPSICA.py
@@ -58,7 +58,7 @@ class Parser:
 			return ""
 	@staticmethod
 	def __printHelp() -> None:
-		print("This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
+		print("This is the official implementation of the VL-PSI-CA cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ")
 		print()
 		print("Options (case-insensitive): ")
 		print("\t{0} [utf-8|utf-16|...]\t\tSpecify the encoding mode for CSV and TXT outputs. The default value is {1}. ".format(


### PR DESCRIPTION
## Summary

- Restore the scheme-specific names in 20 Python `Parser` help descriptions.
- Keep all surrounding help wording and implementation code unchanged.

## Root cause

Commit `893545c419f9972c00f2e1d48a4aee5eed69be31` unintentionally copied the AA-IB-ME name into every Python `printHelp` description while making `Parser` methods static.

## Validation

- Verified byte-for-byte that each modified file differs from `main` only by its scheme name.
- Executed the `-h -t 0` help path for all 20 corrected scripts.
- Compiled all 26 `Scheme*/Scheme*.py` sources with Python's built-in compiler.
- Ran `git diff --check`.
