### PR TITLE
Align coefficient validation and LaTeX wording

### DIFF
--- a/SchemeCoefficientComputation/SchemeCoefficientComputation.py
+++ b/SchemeCoefficientComputation/SchemeCoefficientComputation.py
@@ -676,32 +676,52 @@ class Solutions:
 			else:
 				return (k, )
 		@staticmethod
-		def __computePowerCoefficients(group:object, roots:tuple|list|set, k:None|Element = None) -> tuple:
-			if isinstance(roots, (tuple, list, set)) and all(isinstance(root, Element) and root.type == ZR or isinstance(root, int) for root in roots):
+		def __computePowerCoefficients(group:object, roots:tuple|list, k:Element|int|float|None = None) -> tuple:
+			flag = False
+			if isinstance(roots, (tuple, list)) and roots:
 				n = len(roots)
-				coefficients = [group.init(ZR, 0)] * n + [group.init(ZR, 1)]
+				if isinstance(roots[0], Element) and all(isinstance(root, Element) and root.type == roots[0].type for root in roots):
+					flag = True
+					zero, one = group.init(roots[0].type, 0), group.init(roots[0].type, 1)
+					offset = k if isinstance(k, Element) and k.type == roots[0].type else None
+				elif isinstance(roots[0], (int, float)) and all(isinstance(root, (int, float)) for root in roots):
+					flag = True
+					zero, one = 0, 1
+					offset = k if isinstance(k, (int, float)) else None
+			if flag:
+				coefficients = [zero] * n + [one]
 				for r in roots:
 					for i in range(n):
 						coefficients[i] += r * coefficients[i + 1]
 				coefficients = [(-1) ** (n - i) * coefficients[i] for i in range(n + 1)]
-				if isinstance(k, Element) and k.type == ZR or isinstance(k, int):
-					coefficients[0] += k
+				if offset is not None:
+					coefficients[0] += offset
 				return tuple(coefficients)
 			else:
 				return (k, )
 		@staticmethod
-		def __computeBitwiseAndCoefficients(group:object, roots:tuple|list|set, k:None|Element = None) -> tuple:
-			if isinstance(roots, (tuple, list, set)) and all(isinstance(root, Element) and root.type == ZR or isinstance(root, int) for root in roots):
+		def __computeBitwiseAndCoefficients(group:object, roots:tuple|list, k:Element|int|float|None = None) -> tuple:
+			flag = False
+			if isinstance(roots, (tuple, list)) and roots:
 				n = len(roots)
+				if isinstance(roots[0], Element) and all(isinstance(root, Element) and root.type == roots[0].type for root in roots):
+					flag = True
+					zero, one = group.init(roots[0].type, 0), group.init(roots[0].type, 1)
+					offset = k if isinstance(k, Element) and k.type == roots[0].type else None
+				elif isinstance(roots[0], (int, float)) and all(isinstance(root, (int, float)) for root in roots):
+					flag = True
+					zero, one = 0, 1
+					offset = k if isinstance(k, (int, float)) else None
+			if flag:
 				cnt = n - 1
-				coefficients = [group.init(ZR, 0)] * n + [group.init(ZR, 1)]
+				coefficients = [zero] * n + [one]
 				for r in roots:
 					for i in range(cnt, n):
 						coefficients[i] += r * coefficients[i + 1]
 					cnt -= 1
 				coefficients = [-coefficients[i] if (n - i) & 1 else coefficients[i] for i in range(n + 1)]
-				if isinstance(k, Element) and k.type == ZR or isinstance(k, int):
-					coefficients[0] += k
+				if offset is not None:
+					coefficients[0] += offset
 				return tuple(coefficients)
 			else:
 				return (k, )
@@ -796,32 +816,52 @@ class Solutions:
 			else:
 				return (k, )
 		@staticmethod
-		def __computePowerCoefficients(group:object, roots:tuple|list|set, k:None|Element = None) -> tuple:
-			if isinstance(roots, (tuple, list, set)) and all(isinstance(root, Element) and root.type == ZR or isinstance(root, int) for root in roots):
+		def __computePowerCoefficients(group:object, roots:tuple|list, k:Element|int|float|None = None) -> tuple:
+			flag = False
+			if isinstance(roots, (tuple, list)) and roots:
 				n = len(roots)
-				coefficients = [group.init(ZR, 1)] + [group.init(ZR, 0)] * n
+				if isinstance(roots[0], Element) and all(isinstance(root, Element) and root.type == roots[0].type for root in roots):
+					flag = True
+					zero, one = group.init(roots[0].type, 0), group.init(roots[0].type, 1)
+					offset = k if isinstance(k, Element) and k.type == roots[0].type else None
+				elif isinstance(roots[0], (int, float)) and all(isinstance(root, (int, float)) for root in roots):
+					flag = True
+					zero, one = 0, 1
+					offset = k if isinstance(k, (int, float)) else None
+			if flag:
+				coefficients = [one] + [zero] * n
 				for r in roots:
 					for i in range(n, 0, -1):
 						coefficients[i] += r * coefficients[i - 1]
 				coefficients = [(-1) ** i * coefficients[i] for i in range(n + 1)]
-				if isinstance(k, Element) and k.type == ZR or isinstance(k, int):
-					coefficients[-1] += k
+				if offset is not None:
+					coefficients[-1] += offset
 				return tuple(coefficients)
 			else:
 				return (k, )
 		@staticmethod
-		def __computeBitwiseAndCoefficients(group:object, roots:tuple|list, k:None|Element = None) -> tuple:
-			if isinstance(roots, (tuple, list)) and all(isinstance(root, Element) and root.type == ZR or isinstance(root, int) for root in roots):
+		def __computeBitwiseAndCoefficients(group:object, roots:tuple|list, k:Element|int|float|None = None) -> tuple:
+			flag = False
+			if isinstance(roots, (tuple, list)) and roots:
 				n = len(roots)
+				if isinstance(roots[0], Element) and all(isinstance(root, Element) and root.type == roots[0].type for root in roots):
+					flag = True
+					zero, one = group.init(roots[0].type, 0), group.init(roots[0].type, 1)
+					offset = k if isinstance(k, Element) and k.type == roots[0].type else None
+				elif isinstance(roots[0], (int, float)) and all(isinstance(root, (int, float)) for root in roots):
+					flag = True
+					zero, one = 0, 1
+					offset = k if isinstance(k, (int, float)) else None
+			if flag:
 				cnt = 1
-				coefficients = [group.init(ZR, 1)] + [group.init(ZR, 0)] * n
+				coefficients = [one] + [zero] * n
 				for r in roots:
 					for i in range(cnt, 0, -1):
 						coefficients[i] += r * coefficients[i - 1]
 					cnt += 1
 				coefficients = [-coefficients[i] if i & 1 else coefficients[i] for i in range(n + 1)]
-				if isinstance(k, Element) and k.type == ZR or isinstance(k, int):
-					coefficients[-1] += k
+				if offset is not None:
+					coefficients[-1] += offset
 				return tuple(coefficients)
 			else:
 				return (k, )

--- a/buildSchemeLaTeXPDFs.py
+++ b/buildSchemeLaTeXPDFs.py
@@ -259,12 +259,14 @@ class Builder:
 			"Parser: The output file path passed looks like a directory, which would be connected with the default file name {0}. ", 
 			"Parser: The path {0} exists not to be a regular file. ", "Please press the Enter key to exit ({0}). ", 
 			"Please install the libraries via the active Python package manager (e.g., pip). ", "Please refer to https://github.com/JHUISI/charm if necessary. ", 
+			"Please wait {0} second(s) for automatic exit, or exit manually, for example by pressing Ctrl + C ({1}). ", 
 			"Please wait {0} second(s) for automatic exit, or exit manually, for example by pressing ``Ctrl + C`` ({1}). ", "Space:", 
 			"The runtime environment of the Python Charm-Crypto framework is not correctly configured. ", 
 			"The runtime environment of the Python NumPy and SymPy libraries is not correctly configured. ", 
 			"The runtime environment of the Python NumPy library is not correctly configured. ", 
 			"The execution has finished ({0}). ",
 			"The execution has started. ", "The experiments were interrupted by users. Saved results are retained. ", "The experiments were interrupted by {0}. Saved results are retained. ", 
+			"This cryptographic scheme will be executed in a limited mode. ", 
 			"This is a possible implementation of the AIBE cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ", 
 			"This is a possible implementation of the ARES cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ", 
 			"This is a possible implementation of the CA-NI-PSI cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ", 
@@ -276,6 +278,7 @@ class Builder:
 			"This is the official implementation of the AA-IB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ", 
 			"This is the official implementation of the AnonymousME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ", 
 			"This is the official implementation of the CA-NI-FPPCT cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ", 
+			"This is the official implementation of the coefficient computation cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework and the Python NumPy library. ", 
 			"This is the official implementation of the FS-MUAEKS cryptographic scheme in the Python programming language based on the Python NumPy and SymPy libraries. ", 
 			"This is the official implementation of the HIB-ME cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ", 
 			"This is the official implementation of the IBMEMR cryptographic scheme in the Python programming language based on the Python Charm-Crypto framework. ", 
@@ -318,6 +321,13 @@ class Builder:
 		if self.__collectionMode:
 			if string not in Builder.__GenerationDiagnostics["Function"]:
 				Builder.__GenerationDiagnostics["Function"].append(string)
+			return True
+		elif string in (
+			"Basic: Failed to initialize the curve with name {0} due to {1}. ", "Basic: {0} failed on {1} due to {2}. ", 
+			"Device: Failed to parse {0} due to {1}. ", "Device: Failed to patch {0} with {1} due to {2}. ", "Device: {0} failed on {1} due to {2}. ", 
+			"Is the scheme correct? {0}. ", "Time: {0}", "curveName: {0}", "curveNames: {0}", "one: {0}", "runCount: {0}", 
+			"scheme: base", "scheme: {0}", "solution: {0}"
+		):
 			return True
 		elif not functionName:
 			self.__generationDiagnostics["Function"].append("The statement {0} appears in a private function. ".format(repr(string)))


### PR DESCRIPTION
## Summary

- align the Power and Bitwise-And coefficient baselines with the validation and type-handling conventions used by the other coefficient solutions
- infer the pairing-element type from homogeneous roots, support homogeneous numeric roots, and reject empty or unsupported root collections consistently
- recognize all intentional console statements emitted by `SchemeCoefficientComputation.py` as official LaTeX-builder wording

## Root cause

The four baseline methods used a separate validation path that accepted empty and `set` inputs, only handled integers, and hard-coded `ZR` instead of validating homogeneous element types. The LaTeX builder's statement allowlists also predated the comparator's runtime output, so a successful build reported 23 false-positive wording warnings.

## Validation

- exercised all four methods with numeric, invalid, and homogeneous pairing-element inputs using a fake Charm group
- confirmed the validation-style regression tests pass (4 tests)
- confirmed an end-to-end LaTeX generation test reports empty statement diagnostics
- generated and compiled the SchemeCoefficientComputation LaTeX/PDF successfully with no wording warnings
- verified the pull request contains only the two requested Python files
